### PR TITLE
add more expansive tests to createState functionality

### DIFF
--- a/integration-tests/create-state.test.ts
+++ b/integration-tests/create-state.test.ts
@@ -250,17 +250,18 @@ describe("createState", () => {
             "data-testid": "listComponent",
             children: [
               state.useValueIterator<Item>(
-                ({ elementState }) => {
-                  onUnmount(unmountSpy);
-                  return createElement("li", {
-                    children: [
-                      elementState.useValueSelector(
-                        (element) => element.text,
-                        (text) => createElement("span", { children: text })
-                      ),
-                    ],
-                  });
-                },
+                ({ elementState }) =>
+                  createElement(() => {
+                    onUnmount(unmountSpy);
+                    return createElement("li", {
+                      children: [
+                        elementState.useValueSelector(
+                          (element) => element.text,
+                          (text) => createElement("span", { children: text })
+                        ),
+                      ],
+                    });
+                  }),
                 { key: "id" }
               ),
             ],

--- a/integration-tests/create-state.test.ts
+++ b/integration-tests/create-state.test.ts
@@ -293,4 +293,39 @@ describe("createState", () => {
     expect(listElement.childNodes.length).toBe(4);
     expect(unmountSpy).toHaveBeenCalledTimes(1);
   });
+
+  test("useAttribute does not re-mount the component", async () => {
+    const user = userEvent.setup();
+    const spyFn = jest.fn();
+    function StateComponent() {
+      onUnmount(spyFn);
+      const valueState = createState(0);
+      return createElement("div", {
+        children: [
+          createElement("button", {
+            "data-testvalue": valueState.useAttribute((value) => String(value)),
+            "data-testid": "button",
+            onClick: () => {
+              valueState.setValue((currentValue) => currentValue + 1);
+            },
+          }),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(StateComponent),
+    });
+
+    const btn = screen.getByTestId("button");
+    expect(btn).toHaveAttribute("data-testvalue", "0");
+
+    await user.click(btn);
+    expect(btn).toHaveAttribute("data-testvalue", "1");
+
+    await user.click(btn);
+    expect(btn).toHaveAttribute("data-testvalue", "2");
+    expect(spyFn).not.toHaveBeenCalled();
+  });
 });

--- a/src/attach-component.ts
+++ b/src/attach-component.ts
@@ -16,6 +16,12 @@ function attachComponent({
   const wrappedApp = createElement("div", { children: [component] });
   const { velesElementNode } = getComponentVelesNode(wrappedApp);
   htmlElement.appendChild(velesElementNode.html);
+
+  // TODO: iterate over every child and call their `onUnmout` method
+  // and add tests for that
+  return () => {
+    velesElementNode.html.remove();
+  };
 }
 
 export { attachComponent };

--- a/src/hooks/create-state.ts
+++ b/src/hooks/create-state.ts
@@ -9,7 +9,7 @@ type AttributeHelper = {
   velesAttribute: boolean;
 };
 
-type State<ValueType> = {
+export type State<ValueType> = {
   trackValue(cb: (value: ValueType) => void | Function): void;
   useValue(
     cb: (value: ValueType) => VelesElement | VelesComponent
@@ -166,7 +166,9 @@ function createState<T>(
           return;
         }
 
-        const node = cb({ elementState, index });
+        // we have to wrap it into our own component
+        // to make sure that the unmount handler will have correct context
+        let node = createElement(() => cb({ elementState, index }));
 
         elementsByKey[calculatedKey] = {
           node,
@@ -249,6 +251,8 @@ function createState<T>(
         result._triggerUpdates();
       }
     },
+    // TODO: remove it from this object completely
+    // and access it from closure
     _triggerUpdates: () => {
       trackingElements = trackingElements.map(({ cb, node }) => {
         const newNode = cb(value);
@@ -448,7 +452,9 @@ function createState<T>(
               };
             } else {
               const elementState = createState(element);
-              const node = cb({ elementState, index });
+              // we have to wrap it into our own component
+              // to make sure that the unmount handler will have correct context
+              const node = createElement(() => cb({ elementState, index }));
 
               newRenderedElements.push([node, calculatedKey, elementState]);
               newElementsByKey[calculatedKey] = {

--- a/src/hooks/create-state.ts
+++ b/src/hooks/create-state.ts
@@ -166,9 +166,7 @@ function createState<T>(
           return;
         }
 
-        // we have to wrap it into our own component
-        // to make sure that the unmount handler will have correct context
-        let node = createElement(() => cb({ elementState, index }));
+        let node = cb({ elementState, index });
 
         elementsByKey[calculatedKey] = {
           node,
@@ -452,9 +450,7 @@ function createState<T>(
               };
             } else {
               const elementState = createState(element);
-              // we have to wrap it into our own component
-              // to make sure that the unmount handler will have correct context
-              const node = createElement(() => cb({ elementState, index }));
+              const node = cb({ elementState, index });
 
               newRenderedElements.push([node, calculatedKey, elementState]);
               newElementsByKey[calculatedKey] = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,5 @@ export { attachComponent } from "./attach-component";
 export { createElement } from "./create-element";
 export { createState, combineState, onMount, onUnmount } from "./hooks";
 export { createRef } from "./create-ref";
+
+export type { State } from "./hooks/create-state";


### PR DESCRIPTION
## Description

Add more expansive tests to `createState` functionality. I've added a return function from `attachComponent` to help with the cleanup, although it can help with embedding the library as well.