### PR TITLE
add string, null and undefined as return values from components

### DIFF
--- a/integration-tests/create-element.test.ts
+++ b/integration-tests/create-element.test.ts
@@ -191,4 +191,57 @@ describe("createElement", () => {
         .join("")
     );
   });
+
+  test("supports returning string from a component", async () => {
+    function StringComponent() {
+      return "hello, world";
+    }
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(StringComponent),
+    });
+
+    expect(await screen.findByText("hello, world")).toBeVisible();
+  });
+
+  test("support returning a string from a nested component", async () => {
+    function StringComponent() {
+      return "hello, world";
+    }
+    function App() {
+      return createElement("div", {
+        children: [
+          createElement("h1", { children: ["parent component"] }),
+          createElement(StringComponent),
+        ],
+      });
+    }
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(App),
+    });
+
+    expect(await screen.findByText("parent component")).toBeVisible();
+    expect(await screen.findByText("hello, world")).toBeVisible();
+  });
+
+  test("support returning null from a component", async () => {
+    function StringComponent() {
+      return null;
+    }
+    function App() {
+      return createElement("div", {
+        children: [
+          createElement("h1", { children: ["parent component"] }),
+          createElement(StringComponent),
+        ],
+      });
+    }
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(App),
+    });
+
+    expect(await screen.findByText("parent component")).toBeVisible();
+  });
 });

--- a/src/create-element/create-element.ts
+++ b/src/create-element/create-element.ts
@@ -2,10 +2,15 @@ import { parseChildren } from "./parse-children";
 import { assignAttributes } from "./assign-attributes";
 import { parseComponent } from "./parse-component";
 
-import type { VelesComponent, VelesElement, VelesElementProps } from "../types";
+import type {
+  VelesComponent,
+  VelesElement,
+  VelesElementProps,
+  ComponentFunction,
+} from "../types";
 
 function createElement(
-  element: string | Function,
+  element: string | ComponentFunction,
   props: VelesElementProps = {}
 ): VelesElement | VelesComponent {
   if (typeof element === "string") {

--- a/src/create-element/parse-children.ts
+++ b/src/create-element/parse-children.ts
@@ -74,7 +74,7 @@ function parseChildren({
         if (!velesElementNode) {
           console.error("can't find HTML tree in a component chain");
         } else {
-          if (velesElementNode.phantom) {
+          if ("velesNode" in velesElementNode && velesElementNode.phantom) {
             // we need to get ALL the children of it and attach it to this node
             velesElementNode.childComponents.forEach(
               (childComponentofPhantom) => {

--- a/src/hooks/create-state.ts
+++ b/src/hooks/create-state.ts
@@ -486,7 +486,7 @@ function createState<T>(
           let newElementsCount: number = 0;
           // to avoid unnecessary shuffling of the DOM elements
           let offset: number = 0;
-          let currentElement: HTMLElement | null = null;
+          let currentElement: HTMLElement | Text | null = null;
           newRenderedElements.forEach((newRenderedElement, index) => {
             // if we needed to adjust offset until we reach the original position of the item
             // we need to return it back once we reach the position after it
@@ -596,10 +596,14 @@ function createState<T>(
                 oldRenderedVelesNode.html.remove();
                 oldNode._privateMethods._callUnmountHandlers();
 
-                wrapperVelesElementNode.childComponents =
-                  wrapperVelesElementNode.childComponents.filter(
-                    (childComponent) => childComponent !== oldNode
-                  );
+                if ("velesNode" in wrapperVelesElementNode) {
+                  wrapperVelesElementNode.childComponents =
+                    wrapperVelesElementNode.childComponents.filter(
+                      (childComponent) => childComponent !== oldNode
+                    );
+                } else {
+                  throw new Error("Wrapper iterator element is a string");
+                }
               }
             });
           }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -19,11 +19,17 @@ export type VelesElement = {
   };
 };
 
+export type VelesStringElement = {
+  velesStringElement: true;
+  html: Text;
+  parentVelesElement?: VelesElement;
+};
+
 // an internal representation of components in the tree
 export type VelesComponent = {
   velesComponent: true;
 
-  tree: VelesElement | VelesComponent;
+  tree: VelesElement | VelesComponent | VelesStringElement;
 
   // not intended to be used directly
   _privateMethods: {
@@ -55,3 +61,8 @@ export type ComponentAPI = {
   onMount: (cb: Function) => void;
   onUnmount: (cb: Function) => void;
 };
+
+export type ComponentFunction = (
+  props: VelesElementProps,
+  componentAPI: ComponentAPI
+) => VelesElement | VelesComponent | string | null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
-import type { VelesComponent, VelesElement } from "./types";
+import type { VelesComponent, VelesElement, VelesStringElement } from "./types";
 
 function getComponentVelesNode(component: VelesComponent | VelesElement): {
-  velesElementNode: VelesElement;
+  velesElementNode: VelesElement | VelesStringElement;
   componentsTree: VelesComponent[];
 } {
   const componentsTree: VelesComponent[] = [];
@@ -10,7 +10,14 @@ function getComponentVelesNode(component: VelesComponent | VelesElement): {
   // to the actual HTML to attach it
   while ("velesComponent" in childNode) {
     componentsTree.push(childNode);
-    childNode = childNode.tree;
+    if ("velesStringElement" in childNode.tree) {
+      return {
+        velesElementNode: childNode.tree,
+        componentsTree,
+      };
+    } else {
+      childNode = childNode.tree;
+    }
   }
 
   return { velesElementNode: childNode, componentsTree };


### PR DESCRIPTION
## Description

Add support for strings, null and undefined as returned values from components. `null` can be useful, strings are mostly a QoL change. There will be a similar change to support same returns from `useValue`, there strings will be way more useful.