### PR TITLE
add support for all event handlers

### DIFF
--- a/integration-tests/assign-attributes.test.ts
+++ b/integration-tests/assign-attributes.test.ts
@@ -1,0 +1,79 @@
+import { screen } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
+
+import { attachComponent, createElement, createState, createRef } from "../src";
+
+function shallow(obj1: Record<string, any>, obj2: Record<string, any>) {
+  return (
+    Object.keys(obj1).length === Object.keys(obj2).length &&
+    Object.keys(obj1).every((key) => obj1[key] === obj2[key])
+  );
+}
+
+describe("createState", () => {
+  let cleanup: Function | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  // basic test to make sure event handlers are supported
+  test("supports state updates", async () => {
+    const user = userEvent.setup();
+    const focusFn = jest.fn();
+    const blurFn = jest.fn();
+    function StateComponent() {
+      const inputRef = createRef<HTMLInputElement>();
+      const nameState = createState("");
+      return createElement("div", {
+        children: [
+          createElement("button", {
+            "data-testid": "button",
+            onClick: () => {
+              nameState.setValue(() => "");
+              inputRef.current?.focus();
+            },
+          }),
+          createElement("input", {
+            ref: inputRef,
+            type: "text",
+            "data-testid": "nameInput",
+            name: "name",
+            value: nameState.useAttribute((name) => name),
+            onFocus: focusFn,
+            onBlur: blurFn,
+            onInput: (e) => nameState.setValue(() => e.target.value),
+          }),
+          nameState.useValue((value) =>
+            createElement("div", {
+              children: [`current name is ${value || "empty"}`],
+            })
+          ),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(StateComponent),
+    });
+
+    expect(await screen.findByText("current name is empty")).toBeVisible();
+    const btn = screen.getByTestId("button");
+    const input = screen.getByTestId("nameInput");
+    expect(focusFn).not.toHaveBeenCalled();
+    await user.click(btn);
+    expect(input).toHaveFocus();
+    expect(focusFn).toHaveBeenCalledTimes(1);
+    await user.type(input, "Veles");
+    expect(await screen.findByText("current name is Veles")).toBeVisible();
+    expect(blurFn).not.toHaveBeenCalled();
+    await user.keyboard("{Tab}");
+    expect(blurFn).toHaveBeenCalledTimes(1);
+
+    await user.click(btn);
+    expect(input).toHaveFocus();
+    expect(await screen.findByText("current name is empty")).toBeVisible();
+  });
+});

--- a/src/create-element/assign-attributes.ts
+++ b/src/create-element/assign-attributes.ts
@@ -9,21 +9,26 @@ function assignAttributes({
   htmlElement: HTMLElement;
   velesNode: VelesElement;
 }) {
-  const { onClick, ...otherProps } = props;
-  // we need to assign attributes after `velesNode` is initialized
-  // so that we can correctly handle unmount callbacks
-  Object.entries(otherProps).forEach(([key, value]) => {
-    if (typeof value === "function" && value.velesAttribute === true) {
+  Object.entries(props).forEach(([key, value]) => {
+    const isFunction = typeof value === "function";
+    if (isFunction && value.velesAttribute === true) {
       const attributeValue = value(htmlElement, key, velesNode);
       htmlElement.setAttribute(key, attributeValue);
+    } else if (
+      // basically, any form of `on` handlers, like `onClick`, `onCopy`, etc
+      isFunction &&
+      key.length > 2 &&
+      key.startsWith("on")
+    ) {
+      // TODO: think if this is robust enough
+      htmlElement.addEventListener(
+        key[2].toLocaleLowerCase() + key.slice(3),
+        value
+      );
     } else {
       htmlElement.setAttribute(key, value);
     }
   });
-
-  if (onClick) {
-    htmlElement.addEventListener("click", onClick);
-  }
 }
 
 export { assignAttributes };

--- a/src/create-ref.ts
+++ b/src/create-ref.ts
@@ -1,4 +1,7 @@
-function createRef<T>(initialRefValue: T | null = null) {
+function createRef<T>(initialRefValue: T | null = null): {
+  velesRef: true;
+  current: T | null;
+} {
   return {
     velesRef: true,
     current: initialRefValue,

--- a/src/dom-types.ts
+++ b/src/dom-types.ts
@@ -1,0 +1,193 @@
+export type VelesDOMElementProps = {
+  // Clipboard Events
+  onCopy?: any | undefined;
+  onCopyCapture?: any | undefined;
+  onCut?: any | undefined;
+  onCutCapture?: any | undefined;
+  onPaste?: any | undefined;
+  onPasteCapture?: any | undefined;
+
+  // Composition Events
+  onCompositionEnd?: any | undefined;
+  onCompositionEndCapture?: any | undefined;
+  onCompositionStart?: any | undefined;
+  onCompositionStartCapture?: any | undefined;
+  onCompositionUpdate?: any | undefined;
+  onCompositionUpdateCapture?: any | undefined;
+
+  // Focus Events
+  onFocus?: any | undefined;
+  onFocusCapture?: any | undefined;
+  onBlur?: any | undefined;
+  onBlurCapture?: any | undefined;
+
+  // Form Events
+  onChange?: any | undefined;
+  onChangeCapture?: any | undefined;
+  onBeforeInput?: any | undefined;
+  onBeforeInputCapture?: any | undefined;
+  onInput?: any | undefined;
+  onInputCapture?: any | undefined;
+  onReset?: any | undefined;
+  onResetCapture?: any | undefined;
+  onSubmit?: any | undefined;
+  onSubmitCapture?: any | undefined;
+  onInvalid?: any | undefined;
+  onInvalidCapture?: any | undefined;
+
+  // Image Events
+  onLoad?: any | undefined;
+  onLoadCapture?: any | undefined;
+  onError?: any | undefined; // also a Media Event
+  onErrorCapture?: any | undefined; // also a Media Event
+
+  // Keyboard Events
+  onKeyDown?: any | undefined;
+  onKeyDownCapture?: any | undefined;
+  /** @deprecated */
+  onKeyPress?: any | undefined;
+  /** @deprecated */
+  onKeyPressCapture?: any | undefined;
+  onKeyUp?: any | undefined;
+  onKeyUpCapture?: any | undefined;
+
+  // Media Events
+  onAbort?: any | undefined;
+  onAbortCapture?: any | undefined;
+  onCanPlay?: any | undefined;
+  onCanPlayCapture?: any | undefined;
+  onCanPlayThrough?: any | undefined;
+  onCanPlayThroughCapture?: any | undefined;
+  onDurationChange?: any | undefined;
+  onDurationChangeCapture?: any | undefined;
+  onEmptied?: any | undefined;
+  onEmptiedCapture?: any | undefined;
+  onEncrypted?: any | undefined;
+  onEncryptedCapture?: any | undefined;
+  onEnded?: any | undefined;
+  onEndedCapture?: any | undefined;
+  onLoadedData?: any | undefined;
+  onLoadedDataCapture?: any | undefined;
+  onLoadedMetadata?: any | undefined;
+  onLoadedMetadataCapture?: any | undefined;
+  onLoadStart?: any | undefined;
+  onLoadStartCapture?: any | undefined;
+  onPause?: any | undefined;
+  onPauseCapture?: any | undefined;
+  onPlay?: any | undefined;
+  onPlayCapture?: any | undefined;
+  onPlaying?: any | undefined;
+  onPlayingCapture?: any | undefined;
+  onProgress?: any | undefined;
+  onProgressCapture?: any | undefined;
+  onRateChange?: any | undefined;
+  onRateChangeCapture?: any | undefined;
+  onResize?: any | undefined;
+  onResizeCapture?: any | undefined;
+  onSeeked?: any | undefined;
+  onSeekedCapture?: any | undefined;
+  onSeeking?: any | undefined;
+  onSeekingCapture?: any | undefined;
+  onStalled?: any | undefined;
+  onStalledCapture?: any | undefined;
+  onSuspend?: any | undefined;
+  onSuspendCapture?: any | undefined;
+  onTimeUpdate?: any | undefined;
+  onTimeUpdateCapture?: any | undefined;
+  onVolumeChange?: any | undefined;
+  onVolumeChangeCapture?: any | undefined;
+  onWaiting?: any | undefined;
+  onWaitingCapture?: any | undefined;
+
+  // MouseEvents
+  onAuxClick?: (e: MouseEvent) => any | undefined;
+  onAuxClickCapture?: (e: MouseEvent) => any | undefined;
+  onClick?: (e: MouseEvent) => any | undefined;
+  onClickCapture?: (e: MouseEvent) => any | undefined;
+  onContextMenu?: (e: MouseEvent) => any | undefined;
+  onContextMenuCapture?: (e: MouseEvent) => any | undefined;
+  onDoubleClick?: (e: MouseEvent) => any | undefined;
+  onDoubleClickCapture?: (e: MouseEvent) => any | undefined;
+  onDrag?: any | undefined;
+  onDragCapture?: any | undefined;
+  onDragEnd?: any | undefined;
+  onDragEndCapture?: any | undefined;
+  onDragEnter?: any | undefined;
+  onDragEnterCapture?: any | undefined;
+  onDragExit?: any | undefined;
+  onDragExitCapture?: any | undefined;
+  onDragLeave?: any | undefined;
+  onDragLeaveCapture?: any | undefined;
+  onDragOver?: any | undefined;
+  onDragOverCapture?: any | undefined;
+  onDragStart?: any | undefined;
+  onDragStartCapture?: any | undefined;
+  onDrop?: any | undefined;
+  onDropCapture?: any | undefined;
+  onMouseDown?: (e: MouseEvent) => any | undefined;
+  onMouseDownCapture?: (e: MouseEvent) => any | undefined;
+  onMouseEnter?: (e: MouseEvent) => any | undefined;
+  onMouseLeave?: (e: MouseEvent) => any | undefined;
+  onMouseMove?: (e: MouseEvent) => any | undefined;
+  onMouseMoveCapture?: (e: MouseEvent) => any | undefined;
+  onMouseOut?: (e: MouseEvent) => any | undefined;
+  onMouseOutCapture?: (e: MouseEvent) => any | undefined;
+  onMouseOver?: (e: MouseEvent) => any | undefined;
+  onMouseOverCapture?: (e: MouseEvent) => any | undefined;
+  onMouseUp?: (e: MouseEvent) => any | undefined;
+  onMouseUpCapture?: (e: MouseEvent) => any | undefined;
+
+  // Selection Events
+  onSelect?: any | undefined;
+  onSelectCapture?: any | undefined;
+
+  // Touch Events
+  onTouchCancel?: any | undefined;
+  onTouchCancelCapture?: any | undefined;
+  onTouchEnd?: any | undefined;
+  onTouchEndCapture?: any | undefined;
+  onTouchMove?: any | undefined;
+  onTouchMoveCapture?: any | undefined;
+  onTouchStart?: any | undefined;
+  onTouchStartCapture?: any | undefined;
+
+  // Pointer Events
+  onPointerDown?: any | undefined;
+  onPointerDownCapture?: any | undefined;
+  onPointerMove?: any | undefined;
+  onPointerMoveCapture?: any | undefined;
+  onPointerUp?: any | undefined;
+  onPointerUpCapture?: any | undefined;
+  onPointerCancel?: any | undefined;
+  onPointerCancelCapture?: any | undefined;
+  onPointerEnter?: any | undefined;
+  onPointerLeave?: any | undefined;
+  onPointerOver?: any | undefined;
+  onPointerOverCapture?: any | undefined;
+  onPointerOut?: any | undefined;
+  onPointerOutCapture?: any | undefined;
+  onGotPointerCapture?: any | undefined;
+  onGotPointerCaptureCapture?: any | undefined;
+  onLostPointerCapture?: any | undefined;
+  onLostPointerCaptureCapture?: any | undefined;
+
+  // UI Events
+  onScroll?: any | undefined;
+  onScrollCapture?: any | undefined;
+
+  // Wheel Events
+  onWheel?: any | undefined;
+  onWheelCapture?: any | undefined;
+
+  // Animation Events
+  onAnimationStart?: any | undefined;
+  onAnimationStartCapture?: any | undefined;
+  onAnimationEnd?: any | undefined;
+  onAnimationEndCapture?: any | undefined;
+  onAnimationIteration?: any | undefined;
+  onAnimationIterationCapture?: any | undefined;
+
+  // Transition Events
+  onTransitionEnd?: any | undefined;
+  onTransitionEndCapture?: any | undefined;
+};

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,3 +1,5 @@
+import { VelesDOMElementProps } from "./dom-types";
+
 // an internal representation of DOM nodes in the tree
 // despite being DOM nodes, we still can track mounting/unmounting
 // (although it is not exposed at the moment)
@@ -55,7 +57,7 @@ export type VelesElementProps = {
   // or a function in case we support reactivity
   // TODO: we can improve these types
   [htmlAttribute: string]: any;
-};
+} & VelesDOMElementProps;
 
 export type ComponentAPI = {
   onMount: (cb: Function) => void;


### PR DESCRIPTION
## Description

Add support for all event handlers. Basically, it will try to listen to anything which starts with `on...` name. There are some caveats, e.g. `onChange` works as it is described in the spec, and you need to use `onInput` instead. Also, types are basically a list of all handlers for autocomplete, but `event` types are just `any`, that should be okay for the first release.