### PR TITLE
change parameters order in useValueIterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ function List() {
     children: [
       createElement("h1", { children: "list" }),
       listState.useValueIterator<{ id: number; name: string }>(
+        { key: "id" },
         ({ elementState }) => {
           return createElement("div", {
             children: [
@@ -143,8 +144,7 @@ function List() {
               ),
             ],
           });
-        },
-        { key: "id" }
+        }
       ),
     ],
   });

--- a/integration-tests/create-state.test.ts
+++ b/integration-tests/create-state.test.ts
@@ -412,20 +412,18 @@ describe("createState", () => {
           createElement("ul", {
             "data-testid": "listComponent",
             children: [
-              state.useValueIterator<Item>(
-                ({ elementState }) =>
-                  createElement(() => {
-                    onUnmount(unmountSpy);
-                    return createElement("li", {
-                      children: [
-                        elementState.useValueSelector(
-                          (element) => element.text,
-                          (text) => createElement("span", { children: text })
-                        ),
-                      ],
-                    });
-                  }),
-                { key: "id" }
+              state.useValueIterator<Item>({ key: "id" }, ({ elementState }) =>
+                createElement(() => {
+                  onUnmount(unmountSpy);
+                  return createElement("li", {
+                    children: [
+                      elementState.useValueSelector(
+                        (element) => element.text,
+                        (text) => createElement("span", { children: text })
+                      ),
+                    ],
+                  });
+                })
               ),
             ],
           }),

--- a/src/hooks/create-state.ts
+++ b/src/hooks/create-state.ts
@@ -37,13 +37,13 @@ export type State<ValueType> = {
   ): VelesElement | VelesComponent | VelesStringElement;
   useAttribute(cb: (value: ValueType) => string): AttributeHelper;
   useValueIterator<Element>(
+    options: {
+      key: string | ((options: { element: Element; index: number }) => string);
+    },
     cb: (props: {
       elementState: State<Element>;
       index: number;
-    }) => VelesElement | VelesComponent,
-    options: {
-      key: string | ((options: { element: Element; index: number }) => string);
-    }
+    }) => VelesElement | VelesComponent
   ): VelesComponent | VelesElement;
   getValue(): ValueType;
   getPreviousValue(): undefined | ValueType;
@@ -157,13 +157,13 @@ function createState<T>(
     },
     // TODO: add a version with a selector
     useValueIterator<Element>(
+      options: {
+        key: string | ((options: { element: any; index: number }) => string);
+      },
       cb: (props: {
         elementState: State<Element>;
         index: number;
-      }) => VelesElement | VelesComponent,
-      options: {
-        key: string | ((options: { element: any; index: number }) => string);
-      }
+      }) => VelesElement | VelesComponent
     ) {
       const children: [
         VelesElement | VelesComponent,


### PR DESCRIPTION
## Description

Change parameters order in `useValueIterator`. I think it makes more clear in code, otherwise `key` option might require you to scroll for quite a bit.