### PR TITLE
add jsxs and jsxDEV export functions from jsx-runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Veles
 
 ![Tests status](https://github.com/bloomca/veles/actions/workflows/pull-request-workflow.yaml/badge.svg)
+[![Build Size](https://img.shields.io/bundlephobia/minzip/veles?label=bundle%20size)](https://bundlephobia.com/result?p=veles)
+[![Version](https://img.shields.io/npm/v/veles)](https://www.npmjs.com/package/veles)
 
 > The library is in very early stages and is not published yet as some crucial APIs are still under development
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
   "name": "veles",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "UI library with main focus on performance",
   "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist"

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,2 +1,6 @@
-export { createElement as jsx } from "./create-element";
+export {
+  createElement as jsx,
+  createElement as jsxs,
+  createElement as jsxDEV,
+} from "./create-element";
 export { Fragment } from "./fragment";


### PR DESCRIPTION
## Description

I do not fully understand when exactly different functions are called, but Preact exports the same ([ref](https://github.com/preactjs/preact/blob/main/jsx-runtime/src/index.js)), so I follow their suite.