### PR TITLE
allow plain values to be passed to setValue

### DIFF
--- a/integration-tests/create-state/create-state.test.ts
+++ b/integration-tests/create-state/create-state.test.ts
@@ -61,6 +61,35 @@ describe("createState", () => {
     expect(await screen.findByText("current value is 2")).toBeVisible();
   });
 
+  test("supports direct state updates", async () => {
+    const user = userEvent.setup();
+    function StateComponent() {
+      const nameState = createState(0);
+      return createElement("div", {
+        children: [
+          createElement("input", {
+            "data-testid": "nameInput",
+            onInput: (e) => {
+              nameState.setValue(e.target.value);
+            },
+          }),
+          nameState.useValue((value) =>
+            createElement("div", { children: [`current name is ${value}`] })
+          ),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(StateComponent),
+    });
+
+    const nameInput = screen.getByTestId("nameInput");
+    await user.type(nameInput, "Veles");
+    expect(await screen.findByText("current name is Veles")).toBeVisible();
+  });
+
   // a test to make sure that we can create a state in a parent component,
   // and then pass it down to a child and it will work as expected
   test("supports passing state as a prop", async () => {

--- a/src/hooks/create-state.ts
+++ b/src/hooks/create-state.ts
@@ -64,7 +64,9 @@ export type State<ValueType> = {
   ): VelesComponent | VelesElement | null;
   getValue(): ValueType;
   getPreviousValue(): undefined | ValueType;
-  setValue(newValueCB: (currentValue: ValueType) => ValueType): void;
+  setValue(
+    newValueCB: ((currentValue: ValueType) => ValueType) | ValueType
+  ): void;
 
   // private method, don't use directly
   // TODO: hide completely in a closure
@@ -330,8 +332,10 @@ function createState<T>(
     // set up new value only through the callback which
     // gives the latest value to ensure no outdated data
     // can be used for the state
-    setValue: (newValueCB: (currentValue: T) => T): void => {
-      const newValue = newValueCB(value);
+    setValue: (newValueCB: ((currentValue: T) => T) | T): void => {
+      const newValue =
+        // @ts-expect-error
+        typeof newValueCB === "function" ? newValueCB(value) : newValueCB;
 
       if (newValue !== value) {
         previousValue = value;


### PR DESCRIPTION
## Description

Allow plain value assignment to `state.setValue()`. Sometimes the current value is irrelevant.

Closes https://github.com/Bloomca/veles/issues/24