### PR TITLE
allow to have to no callback function in useValue and useAttribute

### DIFF
--- a/integration-tests/assign-attributes.test.ts
+++ b/integration-tests/assign-attributes.test.ts
@@ -76,4 +76,62 @@ describe("createState", () => {
     expect(input).toHaveFocus();
     expect(await screen.findByText("current name is empty")).toBeVisible();
   });
+
+  test("supports assigning attributes directly without a callback", async () => {
+    const user = userEvent.setup();
+    const focusFn = jest.fn();
+    const blurFn = jest.fn();
+    function StateComponent() {
+      const inputRef = createRef<HTMLInputElement>();
+      const nameState = createState("");
+      return createElement("div", {
+        children: [
+          createElement("button", {
+            "data-testid": "button",
+            onClick: () => {
+              nameState.setValue(() => "");
+              inputRef.current?.focus();
+            },
+          }),
+          createElement("input", {
+            ref: inputRef,
+            type: "text",
+            "data-testid": "nameInput",
+            name: "name",
+            value: nameState.useAttribute(),
+            onFocus: focusFn,
+            onBlur: blurFn,
+            onInput: (e) => nameState.setValue(e.target.value),
+          }),
+          nameState.useValue((value) =>
+            createElement("div", {
+              children: [`current name is ${value || "empty"}`],
+            })
+          ),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(StateComponent),
+    });
+
+    expect(await screen.findByText("current name is empty")).toBeVisible();
+    const btn = screen.getByTestId("button");
+    const input = screen.getByTestId("nameInput");
+    expect(focusFn).not.toHaveBeenCalled();
+    await user.click(btn);
+    expect(input).toHaveFocus();
+    expect(focusFn).toHaveBeenCalledTimes(1);
+    await user.type(input, "Veles");
+    expect(await screen.findByText("current name is Veles")).toBeVisible();
+    expect(blurFn).not.toHaveBeenCalled();
+    await user.keyboard("{Tab}");
+    expect(blurFn).toHaveBeenCalledTimes(1);
+
+    await user.click(btn);
+    expect(input).toHaveFocus();
+    expect(await screen.findByText("current name is empty")).toBeVisible();
+  });
 });

--- a/integration-tests/create-state/create-state.test.ts
+++ b/integration-tests/create-state/create-state.test.ts
@@ -382,4 +382,68 @@ describe("createState", () => {
     await user.click(btn);
     expect(await screen.findByText("current value is 2")).toBeVisible();
   });
+
+  test("supports no callback in useValue to return the value directly", async () => {
+    const user = userEvent.setup();
+    function StateComponent() {
+      const titleState = createState("title");
+      return createElement("div", {
+        children: [
+          createElement("button", {
+            "data-testid": "button",
+            onClick: () => {
+              titleState.setValue("new title");
+            },
+          }),
+          createElement("div", {
+            "data-testid": "container",
+            children: titleState.useValue(),
+          }),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(StateComponent),
+    });
+
+    expect(screen.getByTestId("container").textContent).toBe("title");
+    const btn = screen.getByTestId("button");
+
+    await user.click(btn);
+    expect(screen.getByTestId("container").textContent).toBe("new title");
+  });
+
+  test("supports no callback in useValueSelector to return the value directly", async () => {
+    const user = userEvent.setup();
+    function StateComponent() {
+      const titleState = createState({ title: "title" });
+      return createElement("div", {
+        children: [
+          createElement("button", {
+            "data-testid": "button",
+            onClick: () => {
+              titleState.setValue({ title: "new title" });
+            },
+          }),
+          createElement("div", {
+            "data-testid": "container",
+            children: titleState.useValueSelector((data) => data.title),
+          }),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(StateComponent),
+    });
+
+    expect(screen.getByTestId("container").textContent).toBe("title");
+    const btn = screen.getByTestId("button");
+
+    await user.click(btn);
+    expect(screen.getByTestId("container").textContent).toBe("new title");
+  });
 });


### PR DESCRIPTION
## Description

Allow to have no callback function in `useValue`, `useValueSelector` and `useAttribute`. This is just a syntactic sugar when you want to use the value directly, e.g.:

```jsx
<div>
  {taskNameState.useValue(name => name)}
</div>
```

Closes https://github.com/Bloomca/veles/issues/23