### PR TITLE
automatically registered returned function in mount cb as unmount

### DIFF
--- a/src/create-element/parse-component.ts
+++ b/src/create-element/parse-component.ts
@@ -49,7 +49,13 @@ function parseComponent({
         componentAPI.onUnmount(cb);
       },
       _callMountHandlers: () => {
-        componentMountCbs.forEach((cb) => cb());
+        componentMountCbs.forEach((cb) => {
+          const mountCbResult = cb();
+
+          if (typeof mountCbResult === "function") {
+            componentAPI.onUnmount(mountCbResult);
+          }
+        });
       },
       _callUnmountHandlers: () => {
         componentUnmountCbs.forEach((cb) => cb());

--- a/src/hooks/lifecycle.ts
+++ b/src/hooks/lifecycle.ts
@@ -20,7 +20,9 @@ function popContext() {
   currentContext = contextStack[contextStack.length - 1];
 }
 
-function onMount(cb: Function) {
+// You can return a function from the mount callback, and it will be
+// automatically registered as `onUnmount` callback
+function onMount(cb: () => void | Function) {
   if (currentContext) {
     currentContext.onMount(cb);
   } else {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -74,7 +74,9 @@ export type VelesElementProps = {
 } & VelesDOMElementProps;
 
 export type ComponentAPI = {
-  onMount: (cb: Function) => void;
+  // You can return a function from the mount callback, and it will be
+  // automatically registered as `onUnmount` callback
+  onMount: (cb: Function) => void | Function;
   onUnmount: (cb: Function) => void;
 };
 


### PR DESCRIPTION
## Description

Automatically register a returned function from `onMount` callback as `onUnmount` callback (if returned).

Closes https://github.com/Bloomca/veles/issues/30