### PR TITLE
fix trackingEffects bug when the first value could not be selected

### DIFF
--- a/src/hooks/combine-state.ts
+++ b/src/hooks/combine-state.ts
@@ -84,7 +84,7 @@ export function combineState(...states) {
       // it is guaranteed that reading `state.getValue` will
       // return the updated value
       const updatedValue = states.map((state) => state.getValue());
-      combinedState.setValue(() => updatedValue);
+      combinedState.setValue(updatedValue);
     });
   });
 

--- a/src/hooks/create-state.ts
+++ b/src/hooks/create-state.ts
@@ -436,6 +436,8 @@ function createState<T>(
         }
 
         cb(newSelectedValue);
+        // update selected value
+        trackingEffect.selectedValue = newSelectedValue;
       });
 
       trackingIterators.forEach((trackingIterator) => {


### PR DESCRIPTION
## Description

Fix bug in `trackingEffects`, where the selected value was not updated, so you could not select the first value again.