### PR TITLE
fix bug with conditional returns in useValue

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,4 +57,19 @@ function identity<T>(value1: T, value2: T) {
   return value1 === value2;
 }
 
-export { getComponentVelesNode, identity, callMountHandlers };
+// return an array with elements being there only one time total
+// the first encountered value will be preserved
+function unique<T>(arr: T[]): T[] {
+  const map = new Map<T, true>();
+  const resultArr: T[] = [];
+  arr.forEach((element) => {
+    if (map.has(element)) return;
+
+    map.set(element, true);
+    resultArr.push(element);
+  });
+
+  return resultArr;
+}
+
+export { getComponentVelesNode, identity, callMountHandlers, unique };


### PR DESCRIPTION
## Description

There was a really weird bug, which I am not 100% where it originates from.

The logic was somewhat convoluted. We were reassigning to the same value by calling `.map` on the original array. In theory, it sounds okay, but the problem is that:

1. during the function, an `unmount` callback can be called, which replaces the array we are iterating over
2. during the function, a provided callback will be called, which can call another `useValue`/`useValueSelector`, which would add to the array during the execution

I am not even sure what exactly was happening in these cases. To make it safe, we simply push new values, and then concatenate it with the result of `trackingSelectorElements` (after all the unmounts and new values added). It can have duplicates, so we need to take care of that as well.

I don't think there is anything else like that, but I'll be on the lookout.