### PR TITLE
handle boolean DOM attributes correctly

### DIFF
--- a/integration-tests/assign-attributes.test.ts
+++ b/integration-tests/assign-attributes.test.ts
@@ -134,4 +134,86 @@ describe("createState", () => {
     expect(input).toHaveFocus();
     expect(await screen.findByText("current name is empty")).toBeVisible();
   });
+
+  it('assignes empty string to attributes with a "true" value', () => {
+    function App() {
+      return createElement("div", {
+        children: [
+          createElement("button", {
+            "data-testid": "button",
+            disabled: true,
+          }),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(App),
+    });
+
+    const btn = screen.getByTestId("button");
+
+    expect(btn.getAttribute("disabled")).toBe("");
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('does not assign anything to attributes with a "false" value', () => {
+    function App() {
+      return createElement("div", {
+        children: [
+          createElement("button", {
+            "data-testid": "button",
+            disabled: false,
+          }),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(App),
+    });
+
+    const btn = screen.getByTestId("button");
+
+    expect(btn.getAttribute("disabled")).toBe(null);
+    expect((btn as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("correctly updates boolean properties with useAttribute", async () => {
+    const user = userEvent.setup();
+    function App() {
+      const disabledState = createState(false);
+      return createElement("div", {
+        children: [
+          createElement("button", {
+            "data-testid": "toggleButton",
+            onClick: () => disabledState.setValue((value) => !value),
+          }),
+          createElement("button", {
+            "data-testid": "button",
+            disabled: disabledState.useAttribute(),
+          }),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(App),
+    });
+
+    const testBtn = screen.getByTestId("button");
+    const toggleBtn = screen.getByTestId("toggleButton");
+    await user.click(toggleBtn);
+
+    expect(testBtn.getAttribute("disabled")).toBe("");
+    expect((testBtn as HTMLButtonElement).disabled).toBe(true);
+
+    await user.click(toggleBtn);
+
+    expect(testBtn.getAttribute("disabled")).toBe(null);
+    expect((testBtn as HTMLButtonElement).disabled).toBe(false);
+  });
 });

--- a/src/create-element/assign-attributes.ts
+++ b/src/create-element/assign-attributes.ts
@@ -13,11 +13,17 @@ function assignAttributes({
     const isFunction = typeof value === "function";
     if (isFunction && value.velesAttribute === true) {
       const attributeValue = value(htmlElement, key, velesNode);
-      htmlElement.setAttribute(key, attributeValue);
+      if (typeof attributeValue === "boolean") {
+        // according to the spec, boolean values should just get either an empty string
+        // or duplicated key. I don't see a reason to duplicate the key.
+        // If the value is `false`, no need to set it, the correct behaviour is to remove it.
+        if (value) htmlElement.setAttribute(key, "");
+      } else {
+        htmlElement.setAttribute(key, attributeValue);
+      }
     } else if (
       // basically, any form of `on` handlers, like `onClick`, `onCopy`, etc
       isFunction &&
-      key.length > 2 &&
       key.startsWith("on")
     ) {
       // TODO: think if this is robust enough
@@ -26,7 +32,11 @@ function assignAttributes({
         value
       );
     } else {
-      htmlElement.setAttribute(key, value);
+      if (typeof value === "boolean") {
+        if (value) htmlElement.setAttribute(key, "");
+      } else {
+        htmlElement.setAttribute(key, value);
+      }
     }
   });
 }

--- a/src/hooks/create-state.ts
+++ b/src/hooks/create-state.ts
@@ -302,7 +302,15 @@ function createState<T>(
     trackingAttributes.forEach(({ cb, htmlElement, attributeName }) => {
       const newAttributeValue = cb ? cb(value) : value;
 
-      htmlElement.setAttribute(attributeName, newAttributeValue);
+      if (typeof newAttributeValue === "boolean") {
+        if (newAttributeValue) {
+          htmlElement.setAttribute(attributeName, "");
+        } else {
+          htmlElement.removeAttribute(attributeName);
+        }
+      } else {
+        htmlElement.setAttribute(attributeName, newAttributeValue);
+      }
     });
 
     // tracked values
@@ -768,7 +776,6 @@ function createState<T>(
         // read that array on `_triggerUpdates`
         // and change inline
         // we need to save the HTML element and the name of the attribute
-
         const trackingElement = { cb, htmlElement, attributeName };
         trackingAttributes.push(trackingElement);
 


### PR DESCRIPTION
## Description

According to the spec ([ref](https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML)) boolean values need to be either the same as attribute name or an empty string for `true`, and the attribute needs to be completely removed using `removeAttribute`.

Closes https://github.com/Bloomca/veles/issues/50