### PR TITLE
allow to return usevalue directly from components

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -85,7 +85,7 @@ export type ComponentAPI = {
 export type ComponentFunction = (
   props: VelesElementProps,
   componentAPI: ComponentAPI
-) => VelesElement | VelesComponent | string | null;
+) => VelesElement | VelesComponent | VelesStringElement | string | null;
 
 export type AttributeHelper<T> = {
   (htmlElement: HTMLElement, attributeName: string, node: VelesElement): T;


### PR DESCRIPTION
## Description

Allow to return `useValue` directly from components. The issue was basically the TypeScript was not entirely correct.

Closes https://github.com/Bloomca/veles/issues/49