### PR TITLE
fix incorrect unmount behaviour with usevalue logic

### DIFF
--- a/src/create-element/create-element.ts
+++ b/src/create-element/create-element.ts
@@ -35,7 +35,7 @@ function createElement(
     let unmountHandlers: Function[] = [];
     const callUnmountHandlers = () => {
       // `onUnmount` is logically better to be executed on children first
-      childComponents.forEach((childComponent) => {
+      velesNode.childComponents.forEach((childComponent) => {
         childComponent._privateMethods._callUnmountHandlers();
       });
 

--- a/src/create-element/parse-component.ts
+++ b/src/create-element/parse-component.ts
@@ -58,12 +58,14 @@ function parseComponent({
         });
       },
       _callUnmountHandlers: () => {
-        componentUnmountCbs.forEach((cb) => cb());
         // this should trigger recursive checks, whether it is a VelesNode or VelesComponent
         // string Nodes don't have lifecycle handlers
         if ("_privateMethods" in velesComponent.tree) {
           velesComponent.tree._privateMethods._callUnmountHandlers();
         }
+
+        // we execute own unmount callbacks after children, so the order is reversed
+        componentUnmountCbs.forEach((cb) => cb());
       },
     },
   };

--- a/src/hooks/create-state.ts
+++ b/src/hooks/create-state.ts
@@ -137,6 +137,8 @@ function createState<T>(
 
       const returnednewNode = cb
         ? cb(newSelectedValue)
+        : newSelectedValue == undefined
+        ? ""
         : String(newSelectedValue);
       const newNode =
         !returnednewNode || typeof returnednewNode === "string"
@@ -270,7 +272,7 @@ function createState<T>(
         // callbacks
         parentVelesElement.childComponents =
           parentVelesElement.childComponents.map((childComponent) =>
-            childComponent === node ? newNode : node
+            childComponent === node ? newNode : childComponent
           );
         // we call unmount handlers right after we replace it
         node._privateMethods._callUnmountHandlers();
@@ -661,7 +663,11 @@ function createState<T>(
     ): VelesElement | VelesComponent | VelesStringElement {
       // @ts-expect-error
       const selectedValue = selector ? selector(value) : (value as F);
-      const returnedNode = cb ? cb(selectedValue) : String(selectedValue);
+      const returnedNode = cb
+        ? cb(selectedValue)
+        : selectedValue == undefined
+        ? ""
+        : String(selectedValue);
       const node =
         !returnedNode || typeof returnedNode === "string"
           ? createTextElement(returnedNode as string)


### PR DESCRIPTION
## Description

I accidentally discovered that `useValue` uses an incorrect logic to replace `childComponents` array, which led to some `onUnmount` callbacks being called multiple times (and others potentially never).

Another thing here is that we reverse the `onUnmount` calls, this way we unmount children first, and parent after that, which should be more logical. I don't use it anywhere, and in general it is common not to guarantee the execution order for such things, but I think it makes more sense. It might change in the future if I add promises support to components.