### PR TITLE
do not track attributes value until mounted

### DIFF
--- a/integration-tests/create-state/create-state.test.ts
+++ b/integration-tests/create-state/create-state.test.ts
@@ -276,41 +276,6 @@ describe("createState", () => {
     expect(unmountSpy).toHaveBeenCalledTimes(3);
   });
 
-  test("useAttribute does not re-mount the component", async () => {
-    const user = userEvent.setup();
-    const spyFn = jest.fn();
-    function StateComponent() {
-      onUnmount(spyFn);
-      const valueState = createState(0);
-      return createElement("div", {
-        children: [
-          createElement("button", {
-            "data-testvalue": valueState.useAttribute((value) => String(value)),
-            "data-testid": "button",
-            onClick: () => {
-              valueState.setValue((currentValue) => currentValue + 1);
-            },
-          }),
-        ],
-      });
-    }
-
-    cleanup = attachComponent({
-      htmlElement: document.body,
-      component: createElement(StateComponent),
-    });
-
-    const btn = screen.getByTestId("button");
-    expect(btn).toHaveAttribute("data-testvalue", "0");
-
-    await user.click(btn);
-    expect(btn).toHaveAttribute("data-testvalue", "1");
-
-    await user.click(btn);
-    expect(btn).toHaveAttribute("data-testvalue", "2");
-    expect(spyFn).not.toHaveBeenCalled();
-  });
-
   test("supports strings as returned value in useValue", async () => {
     const user = userEvent.setup();
     function StateComponent() {

--- a/integration-tests/create-state/use-attribute.test.ts
+++ b/integration-tests/create-state/use-attribute.test.ts
@@ -1,0 +1,109 @@
+import { screen } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
+
+import {
+  attachComponent,
+  createElement,
+  createState,
+  onUnmount,
+} from "../../src";
+
+import type { State } from "../../src";
+
+describe("createState", () => {
+  let cleanup: Function | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  test("useAttribute does not re-mount the component", async () => {
+    const user = userEvent.setup();
+    const spyFn = jest.fn();
+    function StateComponent() {
+      onUnmount(spyFn);
+      const valueState = createState(0);
+      return createElement("div", {
+        children: [
+          createElement("button", {
+            "data-testvalue": valueState.useAttribute((value) => String(value)),
+            "data-testid": "button",
+            onClick: () => {
+              valueState.setValue((currentValue) => currentValue + 1);
+            },
+          }),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(StateComponent),
+    });
+
+    const btn = screen.getByTestId("button");
+    expect(btn).toHaveAttribute("data-testvalue", "0");
+
+    await user.click(btn);
+    expect(btn).toHaveAttribute("data-testvalue", "1");
+
+    await user.click(btn);
+    expect(btn).toHaveAttribute("data-testvalue", "2");
+    expect(spyFn).not.toHaveBeenCalled();
+  });
+
+  test("does not track updates in useAttribute until mounted", async () => {
+    const user = userEvent.setup();
+    const spyFn = jest.fn();
+
+    const valueState = createState("initialValue");
+    function App() {
+      const showState = createState(false);
+      const content = createElement("div", {
+        "data-testid": "attributeTest",
+        "data-value": valueState.useAttribute((value) => {
+          spyFn();
+          return value;
+        }),
+      });
+      return createElement("div", {
+        children: [
+          createElement("div", {
+            children: "whatever",
+          }),
+          createElement("button", {
+            "data-testid": "button",
+            onClick: () => showState.setValue((currentValue) => !currentValue),
+          }),
+          showState.useValue((shouldShow) => (shouldShow ? content : null)),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(App),
+    });
+
+    expect(spyFn).toHaveBeenCalledTimes(1);
+    valueState.setValue("newValue1");
+    expect(spyFn).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByTestId("button"));
+    expect(spyFn).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId("attributeTest").getAttribute("data-value")).toBe(
+      "newValue1"
+    );
+    valueState.setValue("newValue2");
+    expect(spyFn).toHaveBeenCalledTimes(3);
+    expect(screen.getByTestId("attributeTest").getAttribute("data-value")).toBe(
+      "newValue2"
+    );
+
+    // remove the element again to see that subscriptions are correctly removed
+    await user.click(screen.getByTestId("button"));
+    valueState.setValue("newValue3");
+    expect(spyFn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/create-element/parse-component.ts
+++ b/src/create-element/parse-component.ts
@@ -3,7 +3,6 @@ import { createTextElement } from "./create-text-element";
 
 import type {
   VelesComponent,
-  VelesStringElement,
   VelesElementProps,
   ComponentAPI,
   ComponentFunction,
@@ -55,7 +54,7 @@ function parseComponent({
             componentAPI.onUnmount(mountCbResult);
           }
         });
-        // componentMountCbs = [];
+        componentMountCbs = [];
       },
       _callUnmountHandlers: () => {
         // this should trigger recursive checks, whether it is a VelesNode or VelesComponent
@@ -66,7 +65,7 @@ function parseComponent({
 
         // we execute own unmount callbacks after children, so the order is reversed
         componentUnmountCbs.forEach((cb) => cb());
-        // componentUnmountCbs = [];
+        componentUnmountCbs = [];
       },
     },
   };

--- a/src/create-state/trigger-updates.ts
+++ b/src/create-state/trigger-updates.ts
@@ -1,5 +1,6 @@
 import { getComponentVelesNode, callMountHandlers, unique } from "../_utils";
 import { updateUseValueSelector } from "./update-usevalue-selector-value";
+import { updateUseAttributeValue } from "./update-useattribute-value";
 
 import type { VelesElement, VelesComponent } from "../types";
 import type {
@@ -35,36 +36,7 @@ function triggerUpdates<T>({
   // attributes
   // the HTML node does not change, so we don't need to modify the array
   trackers.trackingAttributes.forEach((element) => {
-    const { cb, htmlElement, attributeName, attributeValue } = element;
-    const newAttributeValue = cb ? cb(value) : value;
-
-    if (typeof newAttributeValue === "boolean") {
-      if (newAttributeValue) {
-        htmlElement.setAttribute(attributeName, "");
-      } else {
-        htmlElement.removeAttribute(attributeName);
-      }
-    } else if (attributeName.startsWith("on")) {
-      // if the value is the same, it is either not set
-      // or we received the same event handler
-      // either way, no need to do anything
-      if (attributeValue === newAttributeValue) {
-        return;
-      }
-
-      const eventName =
-        attributeName[2].toLocaleLowerCase() + attributeName.slice(3);
-      if (attributeValue) {
-        htmlElement.removeEventListener(eventName, attributeValue);
-      }
-      if (newAttributeValue && typeof newAttributeValue === "function") {
-        htmlElement.addEventListener(eventName, newAttributeValue);
-      }
-      // not the best approach, but it should work as expected
-      element.attributeValue = newAttributeValue;
-    } else {
-      htmlElement.setAttribute(attributeName, newAttributeValue);
-    }
+    updateUseAttributeValue({ element, value });
   });
 
   // tracked values

--- a/src/create-state/types.d.ts
+++ b/src/create-state/types.d.ts
@@ -84,7 +84,7 @@ export type TrackingSelectorElement = {
   node: VelesElement | VelesComponent | VelesStringElement;
 };
 
-type TrackingAttribute = {
+export type TrackingAttribute = {
   cb?: Function;
   htmlElement: HTMLElement;
   attributeName: string;

--- a/src/create-state/update-useattribute-value.ts
+++ b/src/create-state/update-useattribute-value.ts
@@ -1,0 +1,43 @@
+import type { TrackingAttribute } from "./types";
+
+function updateUseAttributeValue<T>({
+  element,
+  value,
+}: {
+  element: TrackingAttribute;
+  value: T;
+}) {
+  const { cb, htmlElement, attributeName, attributeValue } = element;
+  const newAttributeValue = cb ? cb(value) : value;
+
+  if (typeof newAttributeValue === "boolean") {
+    if (newAttributeValue) {
+      htmlElement.setAttribute(attributeName, "");
+    } else {
+      htmlElement.removeAttribute(attributeName);
+    }
+  } else if (attributeName.startsWith("on")) {
+    // if the value is the same, it is either not set
+    // or we received the same event handler
+    // either way, no need to do anything
+    if (attributeValue === newAttributeValue) {
+      return;
+    }
+
+    const eventName =
+      attributeName[2].toLocaleLowerCase() + attributeName.slice(3);
+    if (attributeValue) {
+      htmlElement.removeEventListener(eventName, attributeValue);
+    }
+    if (newAttributeValue && typeof newAttributeValue === "function") {
+      htmlElement.addEventListener(eventName, newAttributeValue);
+    }
+    // not the best approach, but it should work as expected
+    // basically, update the array value in-place
+    element.attributeValue = newAttributeValue;
+  } else {
+    htmlElement.setAttribute(attributeName, newAttributeValue);
+  }
+}
+
+export { updateUseAttributeValue };


### PR DESCRIPTION
## Description

Only track attributes subscription once the node is actually mounted in the DOM.

## Reference

- similar to https://github.com/Bloomca/veles/pull/57
- partially solves https://github.com/Bloomca/veles/issues/45 (`useValueIterator` and `trackValue` are left)