### PR TITLE
add docs about context and guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 This library's primary focus is in performance. What this means is that it allows you to write your code in a way which will ensure that when the data in your app changes, only the smallest relevant parts will update. Despite of similarities with React in syntax, it does not follow the same waterfall style for component re-renders. Instead, it gives you API to subscribe to atomic changes in your tracked state and re-render only parts of the UI which actually depend on the value. Internally, it renders new HTML and replaces the old node. A similar approach is done for attributes, where in case of changes, only the relevant attribute will be updated in place, but nothing else will change.
 
-It is important to note that the performance benefits will only be observed (and relevant as well) in case of a pretty high interactivity. It might not be faster than any other UI framework on the first render, the biggest improvement lies in the power of subscribing to individual changes.
+It is important to note that the performance benefits will only be observed (and relevant as well) in case of a pretty high interactivity. It might not be faster than any other UI framework on the first render, the biggest improvement lies in the power of subscribing to individual changes, which is especially powerful in case of lists.
 
 ## Installation
 
@@ -57,4 +57,4 @@ There also a companion app ([veles-calendar-app](https://github.com/Bloomca/vele
 
 ### Features
 
-The library is under development, so some features are not available yet, namely Context and Portals.
+The library is under development, so some features are not available yet. Namely the TypeScript type inferring is not the best (although the library does support TypeScript), and Portals are not implemented yet.

--- a/docs/api/combine-state.md
+++ b/docs/api/combine-state.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: combineState
-nav_order: 6
+nav_order: 7
 parent: API
 ---
 

--- a/docs/api/create-context.md
+++ b/docs/api/create-context.md
@@ -1,0 +1,125 @@
+---
+layout: default
+title: Context API
+nav_order: 6
+parent: API
+---
+
+## Context API
+
+Veles allows you to create Context, add it to your components and use it in children without passing anything directly; it also helps to encapsulate application-specific data. Keep in mind that Context is completely immutable and won't trigger any re-renders on its own. The only way to get reactivity from the Context is to store a state there, and to subscribe to that state in individual components.
+
+Here is a full example on how to use Context:
+
+```jsx
+import { createContext } from "veles";
+
+const exampleContext = createContext();
+
+function App() {
+  exampleContext.addContext(5);
+  return (
+    <div>
+      <h1>Application</h1>
+      <NestedComponent />
+    </div>
+  );
+}
+
+function NestedComponent() {
+  const value = exampleContext.readContext();
+
+  // the value will be 5
+  return <div>{`Context value is ${value}`}</div>;
+}
+```
+
+> As of right now, there is no `defaultValue` for the Context
+
+As you can see, we created a new Context, then added it inside the `<App>` component, and then read it in the child component.
+
+## Reference
+
+- `createContext()`
+
+Receives no parameters, returns a Context object with the following structure:
+
+- `context.addContext(value)`
+
+Has to be executed inside a component initialization (it won't work properly if you execute it in a lifecycle hook or in some event handler). Adds a value to the Context which will be available to all children, including the ones executed conditionally.
+
+- `context.readContext()`
+
+Read currently saved Context value. If there were several Contexts added of the same object, the latest one will be used.
+
+- `context.Provider`
+
+This is a component which adds Context to all the children. It works almost identical to `context.addContext()` with a major caveat: children cannot be conditional. Because of that, I recommend to go with the `context.addContext()` approach, but you can use this one as well. Here is an example of how to use it:
+
+```jsx
+import { createContext } from "veles";
+
+const exampleContext = createContext();
+
+function App() {
+  return (
+    <exampleContext.Provider value={5}>
+      <div>
+        <h1>Application</h1>
+        <NestedComponent />
+      </div>
+    </exampleContext.Provider>
+  );
+}
+
+function NestedComponent() {
+  const value = exampleContext.readContext();
+
+  // the value will be 5
+  return <div>{`Context value is ${value}`}</div>;
+}
+```
+
+Since the children are not conditional, it will work as expected. Here is an example when it won't work as you expect:
+
+```jsx
+import { createContext, createState } from "veles";
+
+const exampleContext = createContext();
+
+function App() {
+  const showState = createState(false);
+  return (
+    <exampleContext.Provider value={5}>
+      <div>
+        <h1>Application</h1>
+        <NestedComponent />
+        <button
+          onClick={() => showState.setValue((currentValue) => !currentValue)}
+        >
+          Toggle conditional component
+        </button>
+        {showState.useValue((shouldShow) =>
+          shouldShow ? <ConditionalComponent /> : null
+        )}
+      </div>
+    </exampleContext.Provider>
+  );
+}
+
+function NestedComponent() {
+  const value = exampleContext.readContext();
+
+  // the value will be 5
+  return <div>{`Context value is ${value}`}</div>;
+}
+
+function ConditionalComponent() {
+  const value = exampleContext.readContext();
+
+  // the value will be undefined
+  return <div>{`Context value in conditional component is ${value}`}</div>;
+}
+```
+
+The component which is rendered at all times (`<NestedComponent />`) will have the correct Context value, but the conditional one will not. Once you are inside a component, you can use state functions as usual, it is only about the direct children of `context.Provider`.

--- a/docs/api/select-state.md
+++ b/docs/api/select-state.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: selectState
-nav_order: 7
+nav_order: 8
 parent: API
 ---
 

--- a/docs/frameworks-difference.md
+++ b/docs/frameworks-difference.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Differences from other frameworks
-nav_order: 5
+nav_order: 4
 ---
 
 ## Differences from other frameworks
@@ -31,7 +31,6 @@ Overall, with the correct approach, both libraries should give you good interact
 
 The library is pretty much in alpha state, and there are several missing concepts:
 
-- Context
 - Portals
-- No server rendering (this one is not really planned)
 - Not ideal TypeScript support
+- No server rendering (this one is not planned to be supported)

--- a/docs/guides/effective-use-of-state.md
+++ b/docs/guides/effective-use-of-state.md
@@ -1,0 +1,73 @@
+---
+layout: default
+title: Effective use of State
+nav_order: 1
+parent: Guides
+---
+
+## Subscribe to smallest changes
+
+Veles allows you to subscribe to individual updates on very granular level, down to text nodes. Imagine you have a `task` state, and you do something like this:
+
+```jsx
+<div>
+  {taskState.useValue((task) => (
+    <div>
+      <h2>{task.name}</h2>
+      <p>{task.description}</p>
+    </div>
+  ))}
+</div>
+```
+
+In this example when something in the `task` changes, this component will be unmounted, executed again and then mounted back. Not only it means that when the `name` changes, the description node will be re-executed again, but also it something _else_ changes, like labels or updated time, this whole component will be re-evaluated. Instead, use granular subscriptions:
+
+```jsx
+<div>
+  <div>
+    <h2>{taskState.useValueSelector((task) => task.name)}</h2>
+    <p>{taskState.useValueSelector((task) => task.description)}</p>
+  </div>
+</div>
+```
+
+While it looks like a small thing, remember that it could be a much bigger component, there could be a lot of them in the list, and also that DOM operations are by far the most expensive thing in terms of performance hit.
+
+## Efficient conditional checks
+
+When you decide what to render based on some condition, remember that `useValueSelector` will not re-execute it if the returned value did not change. This means that you should always strive for returning primitive values (`boolean`, `number`, `string`, `undefined` and `null`). If you need to access some state properties inside the component, create another subscription there. This is how an efficient code would look like:
+
+```jsx
+<div>
+  {taskState.useValueSelector(
+    (task) => task.labels.length > 5,
+    (showLabels) =>
+      showLabels ? (
+        <ItemWithLabels taskState={taskState} />
+      ) : (
+        <Item taskState={taskState} />
+      )
+  )}
+</div>
+```
+
+You can see that I pass `taskState` to both components, and they can subscribe to individual changes inside. Only when our condition changes, we'll render a different component.
+
+## Working with multiple states
+
+Let's say you have several states and you need to select some data based on both of them. To work with them efficiently, use `combineState` and `selectState`:
+
+```jsx
+// these are aliases for combineState and selectState
+import { combine, select } from "veles/utils";
+
+function projectTasks({ projectState, tasksState }) {
+  const projectIdState = select(projectState, (project) => project.id);
+  const projectTasksState = select(
+    combine(projectIdState, tasksState),
+    ([projectId, tasks]) => tasks.filter((task) => task.projectId === projectId)
+  );
+}
+```
+
+As you can see, first I created a new state to return only `id`, because for the task list we do not care if something else except the `id` changes. After that we build a state which contains only relevant tasks, and it will be easier to work with.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Guides
+nav_order: 3
+has_children: true
+---
+
+## How to use Veles efficiently
+
+Here are some guides on how to get the most out of this library and to solve common problems.

--- a/docs/guides/jsx.md
+++ b/docs/guides/jsx.md
@@ -1,0 +1,27 @@
+---
+layout: default
+title: JSX setup
+nav_order: 2
+parent: Guides
+---
+
+## JSX implementation
+
+JSX itself is a pretty standard React-like implementation. It does have a few quirks:
+
+- you need to use `class` instead of `className` (this will be aliased in the future)
+- `onChange` event works according to the spec ([ref](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)), and it won't be fired after every input update. So you probably want to use `onInput` for now (it will also be aliased in the future)
+
+## JSX setup
+
+To setup it up, you need to use "automatic" JSX runtime (the new version, the "classic" is not supported). For example, in Babel you need to specify:
+
+```js
+[
+  "@babel/preset-react",
+  {
+    runtime: "automatic", // defaults to classic
+    importSource: "veles", // defaults to react
+  },
+];
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ nav_order: 1
 
 # What is Veles
 
-Veles is a component-based UI library focused on performant updates. It allows you to react to changes in your tracked state and update only the nodes which are affected, be it a Text node, or the attribute of a DOM node, only that part will change without touching anything else.
+Veles is a component-based UI library focused on performant updates. It allows you to react to changes in your tracked state and update only the nodes which are affected, be it a Text node, the attribute of a DOM node or the single element in the array; only that part will change without touching anything else.
 
 Veles has special treatment for arrays, meaning that adding new elements, changing existing ones, changing order, or removing elements is efficient and is done with minimal amount of DOM operations.
 
@@ -18,7 +18,7 @@ You can install Veles from npm:
 npm i --save veles
 ```
 
-The library is very small ([2.9KB minified and gzipped](https://bundlephobia.com/package/veles)), and at the moment has no dependencies.
+The library is quite small ([4.2KB minified and gzipped](https://bundlephobia.com/package/veles)), and at the moment has no dependencies.
 
 Let's build a simple counter application:
 


### PR DESCRIPTION
## Description

Add docs for the Context API, add guides on how to use state and set up JSX (although the last one can be expanded with other frameworks and how to use alongside other JSX targets, like React).