### PR TITLE
small utility functions fixes

### DIFF
--- a/integration-tests/utils/combine-state.test.ts
+++ b/integration-tests/utils/combine-state.test.ts
@@ -13,6 +13,7 @@ describe("createState", () => {
   });
 
   test("allows to combine several states", async () => {
+    const spy = jest.fn();
     const user = userEvent.setup();
     function StateComponent() {
       const valueState1 = createState(0);
@@ -23,6 +24,8 @@ describe("createState", () => {
         valueState2,
         valueState3
       );
+
+      combinedValueState.trackValue(spy);
 
       return createElement("div", {
         children: [
@@ -58,6 +61,8 @@ describe("createState", () => {
       component: createElement(StateComponent),
     });
 
+    expect(spy).toHaveBeenCalledTimes(1);
+
     expect(await screen.findByText("current value is 0")).toBeVisible();
     const btn1 = screen.getByTestId("button1");
     const btn2 = screen.getByTestId("button2");
@@ -68,9 +73,13 @@ describe("createState", () => {
     await user.click(btn3);
     expect(await screen.findByText("current value is 3")).toBeVisible();
 
+    expect(spy).toHaveBeenCalledTimes(4);
+
     await user.click(btn2);
     await user.click(btn2);
     await user.click(btn1);
     expect(await screen.findByText("current value is 6")).toBeVisible();
+
+    expect(spy).toHaveBeenCalledTimes(7);
   });
 });

--- a/src/utils/combine-state.ts
+++ b/src/utils/combine-state.ts
@@ -79,13 +79,18 @@ export function combineState(...states) {
   const combinedState = createState(initialValue);
 
   states.forEach((state) => {
-    state.trackValue(() => {
-      // by the time trackValue callback is called
-      // it is guaranteed that reading `state.getValue` will
-      // return the updated value
-      const updatedValue = states.map((state) => state.getValue());
-      combinedState.setValue(updatedValue);
-    });
+    state.trackValue(
+      () => {
+        // by the time trackValue callback is called
+        // it is guaranteed that reading `state.getValue` will
+        // return the updated value
+        const updatedValue = states.map((state) => state.getValue());
+        combinedState.setValue(updatedValue);
+        // the first call wouldn't affect anything anyway, since we can't have any
+        // subscriptions yet, small optimization
+      },
+      { skipFirstCall: true }
+    );
   });
 
   return combinedState;

--- a/src/utils/select-state.ts
+++ b/src/utils/select-state.ts
@@ -12,7 +12,8 @@ function selectState<F, T>(
   state.trackValueSelector(
     selector,
     (selectedState) => {
-      newState.setValue(selectedState);
+      // we use a function because `selectedState` can be a function itself
+      newState.setValue(() => selectedState);
     },
     { skipFirstCall: true }
   );


### PR DESCRIPTION
## Description

Two things:

1. in `select` function, use a function for `setState`, since we can potentially return a function ourselves, and it will be automatically executed if we don't use the function format
2. in `combine` function, we didn't skip the first call, which caused several `setValues` to be executed. It wasn't a problem, because it happened right after the state creation in the same CPU cycle, so the state couldn't have any subscriptions, just a small optimization.