### PR TITLE
Add portals implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 [![Build Size](https://img.shields.io/bundlephobia/minzip/veles?label=bundle%20size)](https://bundlephobia.com/result?p=veles)
 [![Version](https://img.shields.io/npm/v/veles)](https://www.npmjs.com/package/veles)
 
-> This library is still in early stages, so the API is not 100% finalized
-
 `Veles` is a component-based performance-focused UI library. The main goal of this library is to provide a composable way to build highly interactive interfaces, which should be performant out of the box, as long as you follow the recommendations.
 
 ## Performance
@@ -55,7 +53,3 @@ This will render an input and will update the Text node dynamically, without re-
 - [Differences from other frameworks](https://bloomca.github.io/veles/frameworks-difference.html)
 
 There also a companion app ([veles-calendar-app](https://github.com/Bloomca/veles-calendar-app)), which is developed using Veles and is supposed to push it to the limits, identify the issues and ideally improve performance even more.
-
-### Features
-
-The library is under development, so some features are not available yet. Namely the TypeScript type inferring is not the best (although the library does support TypeScript), and Portals are not implemented yet.

--- a/docs/api/portals.md
+++ b/docs/api/portals.md
@@ -1,0 +1,44 @@
+---
+layout: default
+title: Portals
+nav_order: 9
+parent: API
+---
+
+## Portals
+
+If you want to render a part of your application in a different part of the DOM, but want to maintain a logical structure in your components, you can use the `<Portal>` component. This components accepts two props:
+
+- `portalNode`: an HTML component where children will be mounted
+- `children`: any valid Veles children components
+
+## Example
+
+```jsx
+import { Portal, useState } from "veles";
+
+function Component() {
+  const showMenu = useState(false);
+  return (
+    <div
+      onMouseOver={() => showMenu.setState(true)}
+      onMouseOut={() => showMenu.setState(false)}
+    >
+      <h1>Title</h1>
+      {showMenu.useValue((shouldShow) =>
+        shouldShow ? (
+          <Portal portalNode={document.getElementById("portal")}>
+            <div>Component menu</div>
+          </Portal>
+        ) : null
+      )}
+    </div>
+  );
+}
+```
+
+This is a simple example of a menu which will be rendered when we hover over the component, but instead of the app DOM tree, it will use the node with `portal` ID.
+
+## Caveats
+
+If you render multiple Portals to the same `portalNode`, the initial order will be correct. However, if you render Portals conditionally, they will be added to the end of HTML node at the time of their rendering, not respecting the order in the markup. I don't consider it as a bug at the moment, feel free to create an issue if that causes problems.

--- a/docs/frameworks-difference.md
+++ b/docs/frameworks-difference.md
@@ -29,8 +29,4 @@ Overall, with the correct approach, both libraries should give you good interact
 
 ## Veles' drawbacks
 
-The library is pretty much in alpha state, and there are several missing concepts:
-
-- Portals
-- Not ideal TypeScript support
-- No server rendering (this one is not planned to be supported)
+`Veles` strives to provide a small core of features. For example, server rendering is not really planned to support, at least right now.

--- a/integration-tests/portals.test.ts
+++ b/integration-tests/portals.test.ts
@@ -5,16 +5,26 @@ import userEvent from "@testing-library/user-event";
 describe("portals", () => {
   let cleanup: Function | undefined;
 
-  afterEach(() => {
-    cleanup?.();
-    cleanup = undefined;
-  });
-
   const appContainer = document.createElement("div");
   appContainer.setAttribute("data-testid", "app");
   const portalContainer = document.createElement("div");
   portalContainer.setAttribute("data-testid", "portal");
   document.body.append(appContainer, portalContainer);
+
+  // technically, each test asserts that the portal container is empty
+  // but if a test fails, it won't execute the rest and it won't get cleared
+  // so we need this to help debugging
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  function checkCleanup() {
+    cleanup?.();
+    cleanup = undefined;
+
+    expect(portalContainer).toBeEmptyDOMElement();
+  }
 
   test("can render portal directly", () => {
     cleanup = attachComponent({
@@ -41,9 +51,11 @@ describe("portals", () => {
     }
 
     expect(screen.getByTestId("app").textContent).toBe("app titleapp content");
-    // expect(screen.getByTestId("portal").textContent).toBe(
-    //   "portal titleportal container"
-    // );
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "portal titleportal container"
+    );
+
+    checkCleanup();
   });
 
   test("can render portal using <Portal> component", () => {
@@ -74,9 +86,11 @@ describe("portals", () => {
     expect(screen.getByTestId("portal").textContent).toBe(
       "portal titleportal container"
     );
+
+    checkCleanup();
   });
 
-  test("it removes portal content correctly if the Veles app is detached", () => {
+  test("it can render several Portals to the same node", () => {
     cleanup = attachComponent({
       htmlElement: appContainer,
       component: createElement("div", {
@@ -91,8 +105,15 @@ describe("portals", () => {
           createElement(Portal, {
             portalNode: portalContainer,
             children: [
-              createElement("h2", { children: "portal title" }),
-              createElement("div", { children: "portal container" }),
+              createElement("h2", { children: "first portal title" }),
+              createElement("div", { children: "first portal container" }),
+            ],
+          }),
+          createElement(Portal, {
+            portalNode: portalContainer,
+            children: [
+              createElement("h2", { children: "second portal title" }),
+              createElement("div", { children: "second portal container" }),
             ],
           }),
           createElement("div", { children: "app content" }),
@@ -102,13 +123,119 @@ describe("portals", () => {
 
     expect(screen.getByTestId("app").textContent).toBe("app titleapp content");
     expect(screen.getByTestId("portal").textContent).toBe(
-      "portal titleportal container"
+      "first portal titlefirst portal containersecond portal titlesecond portal container"
     );
 
-    cleanup();
-    cleanup = undefined;
+    checkCleanup();
+  });
 
-    expect(screen.getByTestId("portal")).toBeEmptyDOMElement();
+  test("removing one of the Portals does not affect other Portals content", async () => {
+    const showFirstPortalState = createState(true);
+    cleanup = attachComponent({
+      htmlElement: appContainer,
+      component: createElement("div", {
+        children: createElement(Application),
+      }),
+    });
+
+    function Application() {
+      return createElement("div", {
+        children: [
+          createElement("h1", { children: ["app title"] }),
+          showFirstPortalState.useValue((shouldShow) =>
+            shouldShow
+              ? createElement(Portal, {
+                  portalNode: portalContainer,
+                  children: [
+                    createElement("h2", { children: "first portal title" }),
+                    createElement("div", {
+                      children: "first portal container",
+                    }),
+                  ],
+                })
+              : null
+          ),
+          createElement(Portal, {
+            portalNode: portalContainer,
+            children: [
+              createElement("h2", { children: "second portal title" }),
+              createElement("div", { children: "second portal container" }),
+            ],
+          }),
+          createElement("div", { children: "app content" }),
+        ],
+      });
+    }
+
+    expect(screen.getByTestId("app").textContent).toBe("app titleapp content");
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "first portal titlefirst portal containersecond portal titlesecond portal container"
+    );
+
+    showFirstPortalState.setValue(false);
+
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "second portal titlesecond portal container"
+    );
+
+    checkCleanup();
+  });
+
+  test("adding one of the Portals does not affect other Portals content", async () => {
+    const showFirstPortalState = createState(false);
+    cleanup = attachComponent({
+      htmlElement: appContainer,
+      component: createElement("div", {
+        children: createElement(Application),
+      }),
+    });
+
+    function Application() {
+      return createElement("div", {
+        children: [
+          createElement("h1", { children: ["app title"] }),
+          showFirstPortalState.useValue((shouldShow) =>
+            shouldShow
+              ? createElement(Portal, {
+                  portalNode: portalContainer,
+                  children: [
+                    createElement("h2", { children: "first portal title" }),
+                    createElement("div", {
+                      children: "first portal container",
+                    }),
+                  ],
+                })
+              : null
+          ),
+          createElement(Portal, {
+            portalNode: portalContainer,
+            children: [
+              createElement("h2", { children: "second portal title" }),
+              createElement("div", { children: "second portal container" }),
+            ],
+          }),
+          createElement("div", { children: "app content" }),
+        ],
+      });
+    }
+
+    expect(screen.getByTestId("app").textContent).toBe("app titleapp content");
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "second portal titlesecond portal container"
+    );
+
+    showFirstPortalState.setValue(true);
+
+    /**
+     * This is a know quirk, it will add the content to the end. Technically we have enough info to respect
+     * the order in the markup, but I don't think it is particularly important, each Portal content should
+     * have its own container. Maybe it will bite us later.
+     */
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "second portal titlesecond portal containerfirst portal titlefirst portal container"
+    );
+
+    checkCleanup();
   });
 
   test("it renders components correctly in Portal content", () => {
@@ -143,6 +270,48 @@ describe("portals", () => {
     expect(screen.getByTestId("portal").textContent).toBe(
       "portal titlecomponent portal content"
     );
+
+    checkCleanup();
+  });
+
+  test("it renders primitive types as children in Portal correctly", () => {
+    cleanup = attachComponent({
+      htmlElement: appContainer,
+      component: createElement("div", {
+        children: createElement(Application),
+      }),
+    });
+
+    function Application() {
+      return createElement("div", {
+        children: [
+          createElement("h1", { children: ["app title"] }),
+          createElement(Portal, {
+            portalNode: portalContainer,
+            children: [
+              createElement("h2", { children: "portal title" }),
+              1,
+              createElement(PortalContent),
+              "string content",
+              null,
+              2,
+            ],
+          }),
+          createElement("div", { children: "app content" }),
+        ],
+      });
+    }
+
+    function PortalContent() {
+      return createElement("div", { children: "component portal content" });
+    }
+
+    expect(screen.getByTestId("app").textContent).toBe("app titleapp content");
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "portal title1component portal contentstring content2"
+    );
+
+    checkCleanup();
   });
 
   test("it supports conditional rendering of a <Portal> component", async () => {
@@ -193,6 +362,8 @@ describe("portals", () => {
     expect(screen.getByTestId("portal").textContent).toBe(
       "portal titleportal content"
     );
+
+    checkCleanup();
   });
 
   test("it supports conditional rendering inside a <Portal> component", async () => {
@@ -243,5 +414,111 @@ describe("portals", () => {
     expect(screen.getByTestId("portal").textContent).toBe(
       "portal titletoggle content"
     );
+
+    checkCleanup();
+  });
+
+  test("it supports conditional string rendering inside a <Portal> component", async () => {
+    const user = userEvent.setup();
+    cleanup = attachComponent({
+      htmlElement: appContainer,
+      component: createElement("div", {
+        children: createElement(Application),
+      }),
+    });
+
+    function Application() {
+      const showContentState = createState(false);
+      return createElement("div", {
+        children: [
+          createElement("h1", { children: ["app title"] }),
+          createElement(Portal, {
+            portalNode: portalContainer,
+            children: [
+              createElement("h2", { children: "portal title" }),
+              createElement("button", {
+                children: "toggle content",
+                onClick: () =>
+                  showContentState.setValue((currentValue) => !currentValue),
+              }),
+              showContentState.useValue((shouldShow) =>
+                shouldShow ? "portal content" : null
+              ),
+            ],
+          }),
+          createElement("div", { children: "app content" }),
+        ],
+      });
+    }
+
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "portal titletoggle content"
+    );
+
+    await user.click(screen.getByRole("button", { name: "toggle content" }));
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "portal titletoggle contentportal content"
+    );
+
+    await user.click(screen.getByRole("button", { name: "toggle content" }));
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "portal titletoggle content"
+    );
+
+    checkCleanup();
+  });
+
+  test("it supports conditional component rendering inside a <Portal> component", async () => {
+    const user = userEvent.setup();
+    cleanup = attachComponent({
+      htmlElement: appContainer,
+      component: createElement("div", {
+        children: createElement(Application),
+      }),
+    });
+
+    function Application() {
+      const showContentState = createState(false);
+      return createElement("div", {
+        children: [
+          createElement("h1", { children: ["app title"] }),
+          createElement(Portal, {
+            portalNode: portalContainer,
+            children: [
+              createElement("h2", { children: "portal title" }),
+              createElement("button", {
+                children: "toggle content",
+                onClick: () =>
+                  showContentState.setValue((currentValue) => !currentValue),
+              }),
+              showContentState.useValue((shouldShow) =>
+                shouldShow ? createElement(PortalContent) : null
+              ),
+            ],
+          }),
+          createElement("div", { children: "app content" }),
+        ],
+      });
+    }
+
+    function PortalContent() {
+      return createElement("div", { children: "portal content" });
+    }
+
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "portal titletoggle content"
+    );
+
+    await user.click(screen.getByRole("button", { name: "toggle content" }));
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "portal titletoggle contentportal content"
+    );
+
+    await user.click(screen.getByRole("button", { name: "toggle content" }));
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "portal titletoggle content"
+    );
+
+    checkCleanup();
   });
 });

--- a/integration-tests/portals.test.ts
+++ b/integration-tests/portals.test.ts
@@ -625,6 +625,11 @@ describe("portals", () => {
       `portal titleportal container`
     );
 
+    fragmentShowState.setValue(true);
+    expect(screen.getByTestId("portal").textContent).toBe(
+      `portal titleportal fragment titlefragment string1fragment componentportal container`
+    );
+
     checkCleanup();
   });
 });

--- a/integration-tests/portals.test.ts
+++ b/integration-tests/portals.test.ts
@@ -1,0 +1,247 @@
+import { attachComponent, createElement, createState, Portal } from "../src";
+import { screen } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
+
+describe("portals", () => {
+  let cleanup: Function | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  const appContainer = document.createElement("div");
+  appContainer.setAttribute("data-testid", "app");
+  const portalContainer = document.createElement("div");
+  portalContainer.setAttribute("data-testid", "portal");
+  document.body.append(appContainer, portalContainer);
+
+  test("can render portal directly", () => {
+    cleanup = attachComponent({
+      htmlElement: appContainer,
+      component: createElement("div", {
+        children: createElement(Application),
+      }),
+    });
+
+    function Application() {
+      return createElement("div", {
+        children: [
+          createElement("h1", { children: ["app title"] }),
+          createElement("div", {
+            portal: portalContainer,
+            children: [
+              createElement("h2", { children: "portal title" }),
+              createElement("div", { children: "portal container" }),
+            ],
+          }),
+          createElement("div", { children: "app content" }),
+        ],
+      });
+    }
+
+    expect(screen.getByTestId("app").textContent).toBe("app titleapp content");
+    // expect(screen.getByTestId("portal").textContent).toBe(
+    //   "portal titleportal container"
+    // );
+  });
+
+  test("can render portal using <Portal> component", () => {
+    cleanup = attachComponent({
+      htmlElement: appContainer,
+      component: createElement("div", {
+        children: createElement(Application),
+      }),
+    });
+
+    function Application() {
+      return createElement("div", {
+        children: [
+          createElement("h1", { children: ["app title"] }),
+          createElement(Portal, {
+            portalNode: portalContainer,
+            children: [
+              createElement("h2", { children: "portal title" }),
+              createElement("div", { children: "portal container" }),
+            ],
+          }),
+          createElement("div", { children: "app content" }),
+        ],
+      });
+    }
+
+    expect(screen.getByTestId("app").textContent).toBe("app titleapp content");
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "portal titleportal container"
+    );
+  });
+
+  test("it removes portal content correctly if the Veles app is detached", () => {
+    cleanup = attachComponent({
+      htmlElement: appContainer,
+      component: createElement("div", {
+        children: createElement(Application),
+      }),
+    });
+
+    function Application() {
+      return createElement("div", {
+        children: [
+          createElement("h1", { children: ["app title"] }),
+          createElement(Portal, {
+            portalNode: portalContainer,
+            children: [
+              createElement("h2", { children: "portal title" }),
+              createElement("div", { children: "portal container" }),
+            ],
+          }),
+          createElement("div", { children: "app content" }),
+        ],
+      });
+    }
+
+    expect(screen.getByTestId("app").textContent).toBe("app titleapp content");
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "portal titleportal container"
+    );
+
+    cleanup();
+    cleanup = undefined;
+
+    expect(screen.getByTestId("portal")).toBeEmptyDOMElement();
+  });
+
+  test("it renders components correctly in Portal content", () => {
+    cleanup = attachComponent({
+      htmlElement: appContainer,
+      component: createElement("div", {
+        children: createElement(Application),
+      }),
+    });
+
+    function Application() {
+      return createElement("div", {
+        children: [
+          createElement("h1", { children: ["app title"] }),
+          createElement(Portal, {
+            portalNode: portalContainer,
+            children: [
+              createElement("h2", { children: "portal title" }),
+              createElement(PortalContent),
+            ],
+          }),
+          createElement("div", { children: "app content" }),
+        ],
+      });
+    }
+
+    function PortalContent() {
+      return createElement("div", { children: "component portal content" });
+    }
+
+    expect(screen.getByTestId("app").textContent).toBe("app titleapp content");
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "portal titlecomponent portal content"
+    );
+  });
+
+  test("it supports conditional rendering of a <Portal> component", async () => {
+    const user = userEvent.setup();
+    cleanup = attachComponent({
+      htmlElement: appContainer,
+      component: createElement("div", {
+        children: createElement(Application),
+      }),
+    });
+
+    function Application() {
+      const showPortalState = createState(true);
+      return createElement("div", {
+        children: [
+          createElement("h1", { children: ["app title"] }),
+          createElement("button", {
+            children: "toggle menu",
+            onClick: () =>
+              showPortalState.setValue((currentValue) => !currentValue),
+          }),
+          showPortalState.useValue((shouldShow) =>
+            shouldShow
+              ? createElement(Portal, {
+                  portalNode: portalContainer,
+                  children: [
+                    createElement("h2", { children: "portal title" }),
+                    createElement("div", { children: "portal content" }),
+                  ],
+                })
+              : null
+          ),
+          createElement("div", { children: "app content" }),
+        ],
+      });
+    }
+
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "portal titleportal content"
+    );
+
+    // hide the menu
+    await user.click(screen.getByRole("button", { name: "toggle menu" }));
+    expect(screen.getByTestId("portal")).toBeEmptyDOMElement();
+
+    // show the menu again
+    await user.click(screen.getByRole("button", { name: "toggle menu" }));
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "portal titleportal content"
+    );
+  });
+
+  test("it supports conditional rendering inside a <Portal> component", async () => {
+    const user = userEvent.setup();
+    cleanup = attachComponent({
+      htmlElement: appContainer,
+      component: createElement("div", {
+        children: createElement(Application),
+      }),
+    });
+
+    function Application() {
+      const showContentState = createState(false);
+      return createElement("div", {
+        children: [
+          createElement("h1", { children: ["app title"] }),
+          createElement(Portal, {
+            portalNode: portalContainer,
+            children: [
+              createElement("h2", { children: "portal title" }),
+              createElement("button", {
+                children: "toggle content",
+                onClick: () =>
+                  showContentState.setValue((currentValue) => !currentValue),
+              }),
+              showContentState.useValue((shouldShow) =>
+                shouldShow
+                  ? createElement("div", { children: "portal content" })
+                  : null
+              ),
+            ],
+          }),
+          createElement("div", { children: "app content" }),
+        ],
+      });
+    }
+
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "portal titletoggle content"
+    );
+
+    await user.click(screen.getByRole("button", { name: "toggle content" }));
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "portal titletoggle contentportal content"
+    );
+
+    await user.click(screen.getByRole("button", { name: "toggle content" }));
+    expect(screen.getByTestId("portal").textContent).toBe(
+      "portal titletoggle content"
+    );
+  });
+});

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -73,7 +73,14 @@ function renderTree(
     // if there is a portal, we don't need to render directly
     // instead, we need to do so in the mount callback
     if (component.portal) {
-      // it is handled by the portal parent element
+      /**
+       * Inserting nodes is handled by the portal parent element.
+       * We still need to assign `parentVelesElement`, so that
+       * `useValue` updates correctly
+       */
+      if (parentVelesElement) {
+        newNode.parentVelesElement = parentVelesElement;
+      }
     } else if (parentVelesElement) {
       if (component.insertAfter) {
         if ("velesComponentObject" in component.insertAfter) {

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -70,7 +70,11 @@ function renderTree(
       },
     };
     const newNode = getExecutedComponentVelesNode(executedComponent);
-    if (parentVelesElement) {
+    // if there is a portal, we don't need to render directly
+    // instead, we need to do so in the mount callback
+    if (component.portal) {
+      // it is handled by the portal parent element
+    } else if (parentVelesElement) {
       if (component.insertAfter) {
         if ("velesComponentObject" in component.insertAfter) {
           const lastNode = insertNode({
@@ -99,7 +103,7 @@ function renderTree(
 
       newNode.parentVelesElement = parentVelesElement;
     }
-    if (component.needExecutedVersion) {
+    if (component.needExecutedVersion || component.portal) {
       component.executedVersion = executedComponent;
     }
     return executedComponent;

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -118,6 +118,9 @@ function renderTree(
     if (component.phantom) {
       executedNode.phantom = component.phantom;
     }
+    if (component.portal) {
+      executedNode.portal = component.portal;
+    }
     executedNode.childComponents = component.childComponents.map(
       (childComponent) =>
         renderTree(childComponent, { parentVelesElement: executedNode })

--- a/src/create-element/create-element.ts
+++ b/src/create-element/create-element.ts
@@ -1,6 +1,7 @@
 import { parseChildren } from "./parse-children";
 import { assignAttributes } from "./assign-attributes";
 import { parseComponent } from "./parse-component";
+import { getExecutedComponentVelesNode } from "../_utils";
 
 import type {
   VelesComponentObject,
@@ -14,7 +15,13 @@ function createElement(
   props: VelesElementProps = {}
 ): VelesElement | VelesComponentObject {
   if (typeof element === "string") {
-    const { children, ref, phantom = false, ...otherProps } = props;
+    const {
+      children,
+      ref,
+      phantom = false,
+      portal = null,
+      ...otherProps
+    } = props;
 
     const newElement = document.createElement(element);
     const velesNode = {} as VelesElement;
@@ -27,6 +34,7 @@ function createElement(
       children,
       htmlElement: newElement,
       velesNode,
+      portal,
     });
 
     // these handlers are attached directly to the DOM element
@@ -38,6 +46,7 @@ function createElement(
     velesNode.velesNode = true;
     velesNode.childComponents = childComponents;
     velesNode.phantom = phantom;
+    velesNode.portal = portal;
 
     // these handlers are used to start tracking `useValue` only when the node
     // is actually mounted in the DOM
@@ -56,6 +65,51 @@ function createElement(
         unmountHandlers.forEach((cb) => cb());
       },
     };
+
+    /**
+     * Since portal node is already mounted in DOM, we can't just attach our HTML to it
+     * imediately. So we attach it only when the component is actually mounted, and detach
+     * when it is unmounted. This way we don't need to iterate the tree manually and
+     * attach/detach in every case we need to change the tree.
+     */
+    if (portal) {
+      velesNode._privateMethods._addMountHandler(function attachNodeOnMount() {
+        velesNode.childComponents.forEach((childComponent) => {
+          if ("velesNode" in childComponent) {
+            portal.append(childComponent.html);
+
+            // TODO: handle phantom nodes as content
+          } else if ("velesStringElement" in childComponent) {
+            portal.append(childComponent.html);
+          } else {
+            const componentNode = getExecutedComponentVelesNode(
+              childComponent.executedVersion
+            );
+            childComponent.html = componentNode.html;
+            portal.append(componentNode.html);
+
+            // TODO: handle phantom nodes as content
+          }
+        });
+      });
+
+      velesNode._privateMethods._addUnmountHandler(
+        function removeNodeOnUnmount() {
+          velesNode.childComponents.forEach((childComponent) => {
+            if ("velesNode" in childComponent) {
+              childComponent.html.remove();
+            } else if ("velesStringElement" in childComponent) {
+              childComponent.html.remove();
+            } else {
+              const componentNode = getExecutedComponentVelesNode(
+                childComponent.executedVersion
+              );
+              componentNode.html.remove();
+            }
+          });
+        }
+      );
+    }
 
     // assign all the DOM attributes, including event listeners
     assignAttributes({ props: otherProps, htmlElement: newElement, velesNode });

--- a/src/create-state/update-usevalue-selector-value.ts
+++ b/src/create-state/update-usevalue-selector-value.ts
@@ -210,14 +210,7 @@ function updateUseValueSelector<T>({
             );
           }
         } catch (e) {
-          console.error("failed to update...");
-          console.log(document.body.innerHTML);
-          console.log(oldVelesElementNode.parentVelesElement.html.innerHTML);
-          console.log(
-            //@ts-expect-error
-            oldVelesElementNode.parentVelesElement.childComponents[0].html
-              .textContent
-          );
+          console.error("failed to update in useValueSelector", e);
         }
       }
     }

--- a/src/create-state/update-usevalue-selector-value.ts
+++ b/src/create-state/update-usevalue-selector-value.ts
@@ -36,7 +36,7 @@ function updateUseValueSelector<T>({
      * to the new array. once we merge all subscriptions, we run
      * `unique` function which will make sure there are no double
      * subscriptions.
-     * 
+     *
      * This is needed because using `map` can potentially create
      * some weird side effects, since in case the node changed,
      * some elements will be dynamically removed from the array
@@ -198,10 +198,17 @@ function updateUseValueSelector<T>({
         );
       } else {
         try {
-          parentVelesElementRendered.html.replaceChild(
-            newVelesElementNode.html,
-            oldVelesElementNode.html
-          );
+          if (parentVelesElementRendered.portal) {
+            parentVelesElementRendered.portal.replaceChild(
+              newVelesElementNode.html,
+              oldVelesElementNode.html
+            );
+          } else {
+            parentVelesElementRendered.html.replaceChild(
+              newVelesElementNode.html,
+              oldVelesElementNode.html
+            );
+          }
         } catch (e) {
           console.error("failed to update...");
           console.log(document.body.innerHTML);
@@ -233,7 +240,7 @@ function updateUseValueSelector<T>({
     }
 
     // we call unmount handlers right after we replace it
-    // this is where the old 
+    // this is where the old
     callUnmountHandlers(node.executedVersion);
 
     addUseValueMountHandler({

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,6 @@ export { createState } from "./create-state";
 export { createRef } from "./create-ref";
 export { Fragment } from "./fragment";
 export { createContext } from "./context";
+export { Portal } from "./portal";
 
 export type { State } from "./create-state/types";

--- a/src/portal.ts
+++ b/src/portal.ts
@@ -1,0 +1,18 @@
+import { createElement } from "./create-element";
+
+import type { VelesChildren } from "./types";
+
+function Portal({
+  children,
+  portalNode,
+}: {
+  children?: VelesChildren;
+  portalNode: HTMLElement;
+}) {
+  return createElement("div", {
+    portal: portalNode,
+    children,
+  });
+}
+
+export { Portal };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -33,6 +33,7 @@ export type ExecutedVelesElement = {
   html: HTMLElement;
 
   phantom?: boolean;
+  portal?: HTMLElement;
 
   // every element except the most top one should have one
   parentVelesElement?: ExecutedVelesElement;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -9,6 +9,7 @@ export type VelesElement = {
   html: HTMLElement;
 
   phantom?: boolean;
+  portal?: null | HTMLElement;
 
   needExecutedVersion?: boolean;
   executedVersion?: ExecutedVelesElement;
@@ -136,6 +137,8 @@ export type VelesElementProps = {
     current: any;
   };
 
+  portal?: HTMLElement;
+
   // event handlers + any html properties
   // the value can be either a string value
   // or a function in case we support reactivity
@@ -167,6 +170,7 @@ export type VelesComponentObject = {
   insertAfter?: VelesComponentObject | HTMLElement | Text | null;
   html?: HTMLElement | Text;
   parentVelesElement?: VelesElement;
+  portal?: HTMLElement;
 
   needExecutedVersion?: boolean;
   executedVersion?: ExecutedVelesComponent;


### PR DESCRIPTION
## Description

Add portals implementation. It is done so by adding a `portal` property to HTML props, as I think it is the easiest way.

It has a limitation that new portal content is always added to the end of the portal HTML node, not respecting the order in the JSX. Personally, I don't expect it to be a big issue, but maybe a fix will be needed for that in the future.

## Reference

Closes https://github.com/Bloomca/veles/issues/35