### PR TITLE
correctly cleanup track value returned function

### DIFF
--- a/integration-tests/create-state/track-value.test.ts
+++ b/integration-tests/create-state/track-value.test.ts
@@ -101,6 +101,37 @@ describe("track-value", () => {
     expect(spyFn).toHaveBeenLastCalledWith(2);
   });
 
+  it("calls cleanup returned from trackValue callback on unmount", () => {
+    const callbackSpy = vi.fn();
+    const cleanupSpy = vi.fn();
+
+    function StateComponent() {
+      const valueState = createState(0);
+
+      valueState.trackValue(() => {
+        callbackSpy();
+        return cleanupSpy;
+      });
+
+      return createElement("div", {
+        children: ["content"],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(StateComponent),
+    });
+
+    expect(callbackSpy).toHaveBeenCalledTimes(1);
+    expect(cleanupSpy).not.toHaveBeenCalled();
+
+    cleanup?.();
+    cleanup = undefined;
+
+    expect(cleanupSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("supports custom subscriptions with state.trackValue with callOnMount option", async () => {
     const user = userEvent.setup();
     const spyFn = vi.fn();

--- a/src/create-state/index.ts
+++ b/src/create-state/index.ts
@@ -188,27 +188,40 @@ function createStateFromCore<T>(
             })
           : (core as unknown as StateCore<F>);
 
+      let latestCleanup: Function | void;
       const trackedValue = selectedCore.get() as F;
+
+      const runCallback = (value: F) => {
+        if (latestCleanup) {
+          latestCleanup();
+        }
+
+        latestCleanup = cb(value);
+      };
 
       if (!options.skipFirstCall) {
         // trigger the callback first time
         // execute the first callback when the component is mounted
         if (options.callOnMount) {
           onMount(() => {
-            cb(trackedValue);
+            runCallback(trackedValue);
           });
         } else {
-          cb(trackedValue);
+          runCallback(trackedValue);
         }
       }
 
       const unsubscribe = selectedCore.on((newSelectedValue) => {
-        cb(newSelectedValue as F);
+        runCallback(newSelectedValue as F);
       });
 
       // track value is attached at the component level
       onUnmount(() => {
         unsubscribe();
+
+        if (latestCleanup) {
+          latestCleanup();
+        }
 
         if ((selectedCore as unknown) !== (core as unknown)) {
           selectedCore.dispose();


### PR DESCRIPTION
## Description

Currently we don't call a returned function from `trackValue`. This makes it very challenging to clean up side effects when the component unmounts, so this PR fixes it

## Reference

Closes https://github.com/Bloomca/veles/issues/82