### PR TITLE
use correct values for some attributes

### DIFF
--- a/integration-tests/assign-attributes.test.ts
+++ b/integration-tests/assign-attributes.test.ts
@@ -212,6 +212,90 @@ describe("assign-attributes", () => {
     expect((testBtn as HTMLButtonElement).disabled).toBe(false);
   });
 
+  it("assigns enumerated attributes from booleans correctly", () => {
+    function App() {
+      return createElement("div", {
+        children: [
+          createElement("div", {
+            "data-testid": "trueDraggable",
+            draggable: true,
+          }),
+          createElement("div", {
+            "data-testid": "falseDraggable",
+            draggable: false,
+          }),
+          createElement("div", {
+            "data-testid": "trueTranslate",
+            translate: true,
+          }),
+          createElement("div", {
+            "data-testid": "falseTranslate",
+            translate: false,
+          }),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(App),
+    });
+
+    const trueDraggable = screen.getByTestId("trueDraggable") as HTMLElement;
+    const falseDraggable = screen.getByTestId("falseDraggable") as HTMLElement;
+    const trueTranslate = screen.getByTestId("trueTranslate");
+    const falseTranslate = screen.getByTestId("falseTranslate");
+
+    expect(trueDraggable.getAttribute("draggable")).toBe("true");
+    expect(falseDraggable.getAttribute("draggable")).toBe("false");
+    expect(trueDraggable.draggable).toBe(true);
+    expect(falseDraggable.draggable).toBe(false);
+
+    expect(trueTranslate.getAttribute("translate")).toBe("yes");
+    expect(falseTranslate.getAttribute("translate")).toBe("no");
+  });
+
+  it("updates enumerated attributes reactively", async () => {
+    const user = userEvent.setup();
+
+    function App() {
+      const draggable$ = createState(false);
+      return createElement("div", {
+        children: [
+          createElement("button", {
+            "data-testid": "toggleButton",
+            onClick: () => draggable$.update((value) => !value),
+          }),
+          createElement("div", {
+            "data-testid": "target",
+            draggable: draggable$.attribute(),
+          }),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(App),
+    });
+
+    const target = screen.getByTestId("target") as HTMLElement;
+    const toggle = screen.getByTestId("toggleButton");
+
+    expect(target.getAttribute("draggable")).toBe("false");
+    expect(target.draggable).toBe(false);
+
+    await user.click(toggle);
+
+    expect(target.getAttribute("draggable")).toBe("true");
+    expect(target.draggable).toBe(true);
+
+    await user.click(toggle);
+
+    expect(target.getAttribute("draggable")).toBe("false");
+    expect(target.draggable).toBe(false);
+  });
+
   it("allows to assign and remove event listeners dynamically", async () => {
     const user = userEvent.setup();
     const state = createState(0);

--- a/src/attribute-utils.ts
+++ b/src/attribute-utils.ts
@@ -1,0 +1,61 @@
+const ENUMERATED_BOOLEAN_ATTRIBUTES: {
+  [attributeName: string]: {
+    trueValue: string;
+    falseValue: string;
+  };
+} = {
+  draggable: {
+    trueValue: "true",
+    falseValue: "false",
+  },
+  contenteditable: {
+    trueValue: "true",
+    falseValue: "false",
+  },
+  spellcheck: {
+    trueValue: "true",
+    falseValue: "false",
+  },
+  translate: {
+    trueValue: "yes",
+    falseValue: "no",
+  },
+};
+
+function assignDomAttribute({
+  htmlElement,
+  attributeName,
+  value,
+}: {
+  htmlElement: HTMLElement;
+  attributeName: string;
+  value: any;
+}) {
+  if (typeof value === "boolean") {
+    const normalizedAttributeName = attributeName.toLowerCase();
+    const enumeratedConfig = ENUMERATED_BOOLEAN_ATTRIBUTES[normalizedAttributeName];
+
+    if (enumeratedConfig) {
+      htmlElement.setAttribute(
+        attributeName,
+        value ? enumeratedConfig.trueValue : enumeratedConfig.falseValue
+      );
+      return;
+    }
+
+    // according to the spec, boolean values should just get either an empty string
+    // or duplicate the attribute name. A lack of the attribute means
+    // the value is `false`.
+    if (value) {
+      htmlElement.setAttribute(attributeName, "");
+    } else {
+      htmlElement.removeAttribute(attributeName);
+    }
+
+    return;
+  }
+
+  htmlElement.setAttribute(attributeName, value);
+}
+
+export { assignDomAttribute };

--- a/src/create-element/assign-attributes.ts
+++ b/src/create-element/assign-attributes.ts
@@ -1,3 +1,5 @@
+import { assignDomAttribute } from "../attribute-utils";
+
 import type { VelesElement } from "../types";
 
 function assignAttributes({
@@ -35,14 +37,11 @@ function assignAttribute({
   ) {
     htmlElement.addEventListener(key.slice(2).toLocaleLowerCase(), value);
   } else {
-    if (typeof value === "boolean") {
-      // according to the spec, boolean values should just get either an empty string
-      // or duplicated key. I don't see a reason to duplicate the key.
-      // If the value is `false`, no need to set it, the correct behaviour is to remove it.
-      if (value) htmlElement.setAttribute(key, "");
-    } else {
-      htmlElement.setAttribute(key, value);
-    }
+    assignDomAttribute({
+      htmlElement,
+      attributeName: key,
+      value,
+    });
   }
 }
 

--- a/src/create-state/update-useattribute-value.ts
+++ b/src/create-state/update-useattribute-value.ts
@@ -1,3 +1,5 @@
+import { assignDomAttribute } from "../attribute-utils";
+
 import type { TrackingAttribute } from "./types";
 
 function updateUseAttributeValue<T>({
@@ -10,17 +12,8 @@ function updateUseAttributeValue<T>({
   const { cb, htmlElement, attributeName, attributeValue } = element;
   const newAttributeValue = cb ? cb(value) : value;
 
-  // Boolean elements require either setting an empty string as a value,
-  // or duplicate the attribute name. A lack of the attribute means
-  // the value is `false`, so we need to treat it differently.
-  if (typeof newAttributeValue === "boolean") {
-    if (newAttributeValue) {
-      htmlElement.setAttribute(attributeName, "");
-    } else {
-      htmlElement.removeAttribute(attributeName);
-    }
-    // check whether we are dealing with event handlers
-  } else if (attributeName.startsWith("on")) {
+  // check whether we are dealing with event handlers
+  if (attributeName.startsWith("on")) {
     // if the value is the same, it is either not set
     // or we received the same event handler
     // either way, no need to do anything
@@ -43,7 +36,11 @@ function updateUseAttributeValue<T>({
     // and to remove a correct event handler
     element.attributeValue = newAttributeValue;
   } else {
-    htmlElement.setAttribute(attributeName, newAttributeValue);
+    assignDomAttribute({
+      htmlElement,
+      attributeName,
+      value: newAttributeValue,
+    });
   }
 }
 


### PR DESCRIPTION
## Description

Apparently, some attributes require actual "true"/"false" string, like `draggable`. So this fixes it for a few attributes (very possible these are not all possible ones).

## Reference

Closes https://github.com/Bloomca/veles/issues/98

- [draggable MDN article](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/draggable)
- [contenteditable MDN article](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/contenteditable#value) (there is a mention that it is enumerated as well)
- [spellcheck MDN article](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/spellcheck)
- [translate MDN article](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/translate)