### PR TITLE
fix form tags value attribute assignment

### DIFF
--- a/integration-tests/assign-attributes.test.ts
+++ b/integration-tests/assign-attributes.test.ts
@@ -11,6 +11,122 @@ describe("assign-attributes", () => {
     cleanup = undefined;
   });
 
+  test("updates the live input value when a reactive value changes", async () => {
+    const user = userEvent.setup();
+
+    function StateComponent() {
+      const name$ = createState("");
+      return createElement("div", {
+        children: [
+          createElement("button", {
+            "data-testid": "resetButton",
+            onClick: () => name$.set(""),
+          }),
+          createElement("input", {
+            type: "text",
+            "data-testid": "nameInput",
+            name: "name",
+            value: name$.attribute(),
+            onInput: (e) => name$.set((e.target as HTMLInputElement).value),
+          }),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(StateComponent),
+    });
+
+    const btn = screen.getByTestId("resetButton");
+    const input = screen.getByTestId("nameInput") as HTMLInputElement;
+
+    await user.type(input, "Veles");
+    expect(input).toHaveValue("Veles");
+
+    await user.click(btn);
+    expect(input).toHaveValue("");
+  });
+
+  test("updates the live textarea value when a reactive value changes", async () => {
+    const user = userEvent.setup();
+
+    function StateComponent() {
+      const bio$ = createState("");
+      return createElement("div", {
+        children: [
+          createElement("button", {
+            "data-testid": "resetButton",
+            onClick: () => bio$.set(""),
+          }),
+          createElement("textarea", {
+            "data-testid": "bioInput",
+            name: "bio",
+            value: bio$.attribute(),
+            onInput: (e) => bio$.set((e.target as HTMLTextAreaElement).value),
+          }),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(StateComponent),
+    });
+
+    const btn = screen.getByTestId("resetButton");
+    const textarea = screen.getByTestId("bioInput") as HTMLTextAreaElement;
+
+    await user.type(textarea, "Veles textarea");
+    expect(textarea).toHaveValue("Veles textarea");
+
+    await user.click(btn);
+    expect(textarea).toHaveValue("");
+  });
+
+  test("updates the live select value when a reactive value changes", async () => {
+    const user = userEvent.setup();
+
+    function StateComponent() {
+      const difficulty$ = createState("easy");
+      return createElement("div", {
+        children: [
+          createElement("button", {
+            "data-testid": "resetButton",
+            onClick: () => difficulty$.set("easy"),
+          }),
+          createElement("select", {
+            "data-testid": "difficultySelect",
+            name: "difficulty",
+            value: difficulty$.attribute(),
+            onChange: (e) => difficulty$.set((e.target as HTMLSelectElement).value),
+            children: [
+              createElement("option", { value: "easy", children: "Easy" }),
+              createElement("option", { value: "normal", children: "Normal" }),
+              createElement("option", { value: "hard", children: "Hard" }),
+            ],
+          }),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(StateComponent),
+    });
+
+    const btn = screen.getByTestId("resetButton");
+    const select = screen.getByTestId("difficultySelect") as HTMLSelectElement;
+
+    expect(select).toHaveValue("easy");
+
+    await user.selectOptions(select, "hard");
+    expect(select).toHaveValue("hard");
+
+    await user.click(btn);
+    expect(select).toHaveValue("easy");
+  });
+
   // basic test to make sure event handlers are supported
   test("supports state updates", async () => {
     const user = userEvent.setup();

--- a/src/attribute-utils.ts
+++ b/src/attribute-utils.ts
@@ -1,3 +1,5 @@
+const FORM_VALUE_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
+
 const ENUMERATED_BOOLEAN_ATTRIBUTES: {
   [attributeName: string]: {
     trueValue: string;
@@ -33,13 +35,29 @@ function assignDomAttribute({
   value: any;
   previousValue?: any;
 }) {
+  const normalizedAttributeName = attributeName.toLowerCase();
+
+  if (normalizedAttributeName === "value" && isFormValueElement(htmlElement)) {
+    assignFormValueProperty(htmlElement, value);
+    return;
+  }
+
+  if (normalizedAttributeName === "checked" && htmlElement.tagName === "INPUT") {
+    assignBooleanProperty(htmlElement as HTMLInputElement, "checked", value);
+    return;
+  }
+
+  if (normalizedAttributeName === "selected" && htmlElement.tagName === "OPTION") {
+    assignBooleanProperty(htmlElement as HTMLOptionElement, "selected", value);
+    return;
+  }
+
   if (attributeName === "style") {
     assignStyle({ value, previousValue, htmlElement });
     return;
   }
 
   if (typeof value === "boolean") {
-    const normalizedAttributeName = attributeName.toLowerCase();
     const enumeratedConfig = ENUMERATED_BOOLEAN_ATTRIBUTES[normalizedAttributeName];
 
     if (enumeratedConfig) {
@@ -70,6 +88,49 @@ function assignDomAttribute({
   }
 
   htmlElement.setAttribute(attributeName, value);
+}
+
+function isFormValueElement(
+  htmlElement: HTMLElement,
+): htmlElement is HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement {
+  return FORM_VALUE_TAGS.has(htmlElement.tagName);
+}
+
+function assignFormValueProperty(
+  htmlElement: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement,
+  value: any,
+) {
+  if (htmlElement.tagName === "SELECT" && Array.isArray(value)) {
+    const selectedValues = new Set(value.map(String));
+
+    Array.from((htmlElement as HTMLSelectElement).options).forEach((option) => {
+      const shouldSelect = selectedValues.has(option.value);
+
+      if (option.selected !== shouldSelect) {
+        option.selected = shouldSelect;
+      }
+    });
+
+    return;
+  }
+
+  const normalizedValue = value == null ? "" : String(value);
+
+  if (htmlElement.value !== normalizedValue) {
+    htmlElement.value = normalizedValue;
+  }
+}
+
+function assignBooleanProperty<T extends "checked" | "selected">(
+  htmlElement: { [Property in T]: boolean },
+  propertyName: T,
+  value: any,
+) {
+  const normalizedValue = Boolean(value);
+
+  if (htmlElement[propertyName] !== normalizedValue) {
+    htmlElement[propertyName] = normalizedValue;
+  }
 }
 
 function assignStyle({


### PR DESCRIPTION
## Description

Fix form tags value attribute assignment. See https://github.com/Bloomca/veles/issues/110 for more details, but in short, we want to assign `.value` directly instead of using `setAttribute`.

## Reference

Closes https://github.com/Bloomca/veles/issues/110