### PR TITLE
Fix nested children

### DIFF
--- a/integration-tests/fragment.test.ts
+++ b/integration-tests/fragment.test.ts
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
 
 import { attachComponent, createElement, Fragment, createState } from "../src";
+import type { VelesChildren } from "../src/types";
 
 describe("<Fragment>", () => {
   let cleanup: Function | undefined;
@@ -9,6 +10,33 @@ describe("<Fragment>", () => {
   afterEach(() => {
     cleanup?.();
     cleanup = undefined;
+  });
+
+  test("flattens child arrays passed through a wrapper component", () => {
+    const visible$ = createState(false);
+
+    function Wrapper({ children }: { children?: VelesChildren }) {
+      return createElement(Fragment, {
+        children: [children, visible$.render(() => null)] as unknown as VelesChildren,
+      });
+    }
+
+    function App() {
+      return createElement(Wrapper, {
+        children: [
+          createElement("span", { "data-testid": "first-child", children: "First" }),
+          createElement("span", { "data-testid": "second-child", children: "Second" }),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(App),
+    });
+
+    expect(screen.getByTestId("first-child").textContent).toBe("First");
+    expect(screen.getByTestId("second-child").textContent).toBe("Second");
   });
 
   test("supports <Fragment> components rendering correctly", () => {

--- a/src/create-element/parse-children.ts
+++ b/src/create-element/parse-children.ts
@@ -7,6 +7,27 @@ import type {
   VelesElementProps,
 } from "../types";
 
+type ParsedChild =
+  | string
+  | number
+  | VelesElement
+  | VelesComponentObject
+  | VelesStringElement
+  | undefined
+  | null;
+
+function flattenChildren(children: unknown): ParsedChild[] {
+  const flattenedChildren: ParsedChild[] = [];
+
+  function append(child: unknown) {
+    if (Array.isArray(child)) child.forEach(append);
+    else flattenedChildren.push(child as ParsedChild);
+  }
+
+  append(children);
+  return flattenedChildren;
+}
+
 function parseChildren({
   children,
   htmlElement,
@@ -27,7 +48,7 @@ function parseChildren({
   // when they are executed
   let lastInsertedNode: null | HTMLElement | Text | VelesComponentObject = null;
 
-  (Array.isArray(children) ? children : [children]).forEach((childComponent) => {
+  flattenChildren(children).forEach((childComponent) => {
     if (typeof childComponent === "string") {
       const textNode = createTextElement(childComponent);
       htmlElement.append(textNode.html);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "types": ["vitest/globals", "@testing-library/jest-dom"],
     "moduleResolution": "bundler",
+    "noEmit": true,
     "skipLibCheck": true
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    extensions: [".ts", ".tsx", ".mjs", ".js", ".mts", ".jsx", ".json"],
+  },
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
## Description

Fix nested children problem. If we had something like:

```tsx
   function Wrapper({ children }) {
     return (
       <>
         {children}
         <ConfirmationRenderer />
       </>
     );
   }
 ```

This resolves to:

```ts
   [
     [<Component1 />, <Component2 />],
     <ConfirmationRenderer />,
   ]
 ```

We called `Array.isArray(children) ? children : [children]` before. It worked because JSX is smart enough to ditch an array if it is a single child, but with multiple children it does not work.