### PR TITLE
Fix deep dirty parents

### DIFF
--- a/integration-tests/create-state/min-heap.test.ts
+++ b/integration-tests/create-state/min-heap.test.ts
@@ -1,0 +1,42 @@
+import { MinHeap } from "../../src/create-state/min-heap";
+
+type RankedValue = {
+  name: string;
+  rank: number;
+};
+
+describe("MinHeap", () => {
+  test("pops values in ascending rank as new values are added", () => {
+    const heap = new MinHeap<RankedValue>((value1, value2) => value1.rank - value2.rank);
+
+    heap.push({ name: "combined", rank: 4 });
+    heap.push({ name: "long branch #1", rank: 1 });
+
+    expect(heap.pop()?.name).toBe("long branch #1");
+
+    heap.push({ name: "long branch #2", rank: 2 });
+    heap.push({ name: "long branch #3", rank: 3 });
+
+    expect(heap.pop()?.name).toBe("long branch #2");
+    expect(heap.pop()?.name).toBe("long branch #3");
+    expect(heap.pop()?.name).toBe("combined");
+    expect(heap.size).toBe(0);
+    expect(heap.pop()).toBeUndefined();
+  });
+
+  test("preserves insertion order for values with the same rank", () => {
+    const heap = new MinHeap<RankedValue>((value1, value2) => value1.rank - value2.rank);
+
+    heap.push({ name: "first rank 2", rank: 2 });
+    heap.push({ name: "rank 1", rank: 1 });
+    heap.push({ name: "second rank 2", rank: 2 });
+    heap.push({ name: "third rank 2", rank: 2 });
+
+    expect([heap.pop()?.name, heap.pop()?.name, heap.pop()?.name, heap.pop()?.name]).toEqual([
+      "rank 1",
+      "first rank 2",
+      "second rank 2",
+      "third rank 2",
+    ]);
+  });
+});

--- a/integration-tests/create-state/state-modifications.test.ts
+++ b/integration-tests/create-state/state-modifications.test.ts
@@ -171,6 +171,25 @@ describe("state modifications", () => {
   });
 
   describe("glitch-free push-pull", () => {
+    test("does not emit an intermediate value in a deep, uneven diamond graph", () => {
+      const source = new StateCore(1);
+      const short = source.map((value) => value + 100);
+      const long = source
+        .map((value) => value * 2)
+        .map((value) => value * 3)
+        .map((value) => value * 5);
+      const combined = short.combine(long);
+
+      expect(combined.get()).toEqual([101, 30]);
+
+      const emissions: [number, number][] = [];
+      combined.on((value) => emissions.push(value as [number, number]));
+
+      source.set(2);
+
+      expect(emissions).toEqual([[102, 60]]);
+    });
+
     test("does not emit inconsistent intermediate states in a diamond graph", () => {
       const a = new StateCore(1);
       const b = a.map((value) => value * 2);

--- a/src/create-state/min-heap.ts
+++ b/src/create-state/min-heap.ts
@@ -1,0 +1,93 @@
+type HeapEntry<T> = {
+  value: T;
+  insertionOrder: number;
+};
+
+/**
+ * A stable min-heap. Values with the same priority are returned in
+ * insertion order.
+ */
+class MinHeap<T> {
+  private _entries: HeapEntry<T>[] = [];
+  private _insertionOrder = 0;
+  private _compareValues: (value1: T, value2: T) => number;
+
+  constructor(compareValues: (value1: T, value2: T) => number) {
+    this._compareValues = compareValues;
+  }
+
+  get size() {
+    return this._entries.length;
+  }
+
+  push(value: T) {
+    const entry = {
+      value,
+      insertionOrder: this._insertionOrder++,
+    };
+    let index = this._entries.length;
+
+    this._entries.push(entry);
+
+    while (index > 0) {
+      const parentIndex = Math.floor((index - 1) / 2);
+      const parentEntry = this._entries[parentIndex];
+
+      if (this.compareEntries(parentEntry, entry) <= 0) break;
+
+      this._entries[index] = parentEntry;
+      index = parentIndex;
+    }
+
+    this._entries[index] = entry;
+  }
+
+  pop(): T | undefined {
+    const firstEntry = this._entries[0];
+    const lastEntry = this._entries.pop();
+
+    if (!firstEntry || !lastEntry) return undefined;
+    if (this._entries.length === 0) return firstEntry.value;
+
+    let index = 0;
+    while (true) {
+      const leftChildIndex = index * 2 + 1;
+      const rightChildIndex = leftChildIndex + 1;
+      let smallestIndex = index;
+
+      if (
+        leftChildIndex < this._entries.length &&
+        this.compareEntries(this._entries[leftChildIndex], lastEntry) < 0
+      ) {
+        smallestIndex = leftChildIndex;
+      }
+
+      if (
+        rightChildIndex < this._entries.length &&
+        this.compareEntries(
+          this._entries[rightChildIndex],
+          smallestIndex === index ? lastEntry : this._entries[leftChildIndex],
+        ) < 0
+      ) {
+        smallestIndex = rightChildIndex;
+      }
+
+      if (smallestIndex === index) break;
+
+      this._entries[index] = this._entries[smallestIndex];
+      index = smallestIndex;
+    }
+
+    this._entries[index] = lastEntry;
+
+    return firstEntry.value;
+  }
+
+  private compareEntries(entry1: HeapEntry<T>, entry2: HeapEntry<T>) {
+    const valueComparison = this._compareValues(entry1.value, entry2.value);
+
+    return valueComparison === 0 ? entry1.insertionOrder - entry2.insertionOrder : valueComparison;
+  }
+}
+
+export { MinHeap };

--- a/src/create-state/state-core.ts
+++ b/src/create-state/state-core.ts
@@ -1,3 +1,5 @@
+import { MinHeap } from "./min-heap";
+
 // explicit symbol for empty value, so it is 100% unique
 const emptyValue = Symbol("veles-state-core-empty");
 
@@ -30,11 +32,14 @@ class StateCore<T> {
   private _children: Set<StateCore<any>> = new Set();
   private _parents: Set<StateCore<any>>;
   private _compute?: () => CoreValue<T>;
+  private _rank: number;
 
   constructor(initialValue: CoreValue<T>, options: CoreOptions<T> = {}) {
     this._value = initialValue;
-    this._parents = new Set(options.parents);
+    const parents = options.parents || [];
+    this._parents = new Set(parents);
     this._compute = options.compute;
+    this._rank = parents.reduce((rank, parent) => Math.max(rank, parent._rank + 1), 0);
     this._dirty = Boolean(options.dirty);
     this._equality = options.equality || defaultEquality;
   }
@@ -201,33 +206,48 @@ class StateCore<T> {
   }
 
   private flush() {
-    const queue = Array.from(this._children);
-    const queued = new Set(queue);
+    /**
+     * We utilize a min-heap to ensure that we don't trigger notifications
+     * before all the previous necessary work is done. Otherwise it can
+     * happen too early, and we'd need to recursively check that every parent
+     * is not dirty and schedule it again.
+     *
+     * Here we achieve this by assinging a rank to each core state, which is
+     * determined by the highest rank of any of the parent + 1.
+     *
+     * After that, we process them at the same rank, ensuring that "short" branches
+     * are not executed before all their parents are done with their recomputation.
+     */
+    const queue = new MinHeap<StateCore<any>>((node1, node2) => node1._rank - node2._rank);
+    const queued = new Set<StateCore<any>>();
+    const enqueue = (node: StateCore<any>) => {
+      if (queued.has(node)) return;
 
-    while (queue.length > 0) {
-      const child = queue.shift()!;
+      queue.push(node);
+      queued.add(node);
+    };
+
+    this._children.forEach(enqueue);
+
+    while (queue.size > 0) {
+      const child = queue.pop()!;
       queued.delete(child);
 
       if (!child._dirty) continue;
 
-      // in case a child has dirty parents, we need to recompute them
-      // first (potentially recursively). If that happens, we need to
-      // process them first, and then process this child node again.
+      // A dirty parent might not have been scheduled by this flush, for example
+      // when a lazily computed state is combined with the state being updated.
+      // Its lower rank ensures it will run before this child after both are queued.
       let shouldRescheduleChild = false;
       child._parents.forEach((parentNode) => {
         if (parentNode._dirty) {
-          if (!queued.has(parentNode)) {
-            queue.push(parentNode);
-            queued.add(parentNode);
-          }
-
+          enqueue(parentNode);
           shouldRescheduleChild = true;
         }
       });
 
       if (shouldRescheduleChild) {
-        queue.push(child);
-        queued.add(child);
+        enqueue(child);
         continue;
       }
 
@@ -239,10 +259,7 @@ class StateCore<T> {
       child.notifySubscribers(value, child._prevValue);
       child._children.forEach((grandchild) => {
         grandchild._dirty = true;
-        if (!queued.has(grandchild)) {
-          queue.push(grandchild);
-          queued.add(grandchild);
-        }
+        enqueue(grandchild);
       });
     }
   }


### PR DESCRIPTION
## Description

This bugfix solves an issue where an uneven diamond graph would emit intermidiate updates with dirty deep parent values due to short branch notifying early.

This is solved with a min heap to ensure that each core state has an appropriate depth rank and then the dependencies are processed in rank order.