### PR TITLE
fix attributes normalization

### DIFF
--- a/integration-tests/assign-attributes.test.ts
+++ b/integration-tests/assign-attributes.test.ts
@@ -244,6 +244,90 @@ describe("assign-attributes", () => {
     expect(await screen.findByText("current name is empty")).toBeVisible();
   });
 
+  it("assigns dangerouslySetInnerHTML as HTML content", () => {
+    const markup = '<span data-testid="injectedContent"><b>injected</b></span>';
+
+    function App() {
+      return createElement("div", {
+        "data-testid": "container",
+        dangerouslySetInnerHTML: { __html: markup },
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(App),
+    });
+
+    const container = screen.getByTestId("container");
+    expect(container.innerHTML).toBe(markup);
+    expect(container).not.toHaveAttribute("dangerouslysetinnerhtml");
+    expect(screen.getByTestId("injectedContent")).toBeVisible();
+  });
+
+  it("maps htmlFor to the for attribute", () => {
+    function App() {
+      return createElement("div", {
+        children: [
+          createElement("label", {
+            "data-testid": "label",
+            htmlFor: "name",
+            children: "Name",
+          }),
+          createElement("input", { id: "name" }),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(App),
+    });
+
+    const label = screen.getByTestId("label") as HTMLLabelElement;
+    expect(label).toHaveAttribute("for", "name");
+    expect(label).not.toHaveAttribute("htmlfor");
+    expect(label.htmlFor).toBe("name");
+  });
+
+  it("stringifies boolean ARIA and data attributes", async () => {
+    const user = userEvent.setup();
+
+    function App() {
+      const hidden$ = createState(false);
+
+      return createElement("div", {
+        children: [
+          createElement("button", {
+            "data-testid": "toggleButton",
+            onClick: () => hidden$.update((hidden) => !hidden),
+          }),
+          createElement("div", {
+            "data-testid": "target",
+            "aria-hidden": hidden$.attribute(),
+            "data-hidden": hidden$.attribute(),
+          }),
+        ],
+      });
+    }
+
+    cleanup = attachComponent({
+      htmlElement: document.body,
+      component: createElement(App),
+    });
+
+    const target = screen.getByTestId("target");
+    const toggleButton = screen.getByTestId("toggleButton");
+
+    expect(target).toHaveAttribute("aria-hidden", "false");
+    expect(target).toHaveAttribute("data-hidden", "false");
+
+    await user.click(toggleButton);
+
+    expect(target).toHaveAttribute("aria-hidden", "true");
+    expect(target).toHaveAttribute("data-hidden", "true");
+  });
+
   it('assignes empty string to attributes with a "true" value', () => {
     function App() {
       return createElement("div", {

--- a/src/attribute-utils.ts
+++ b/src/attribute-utils.ts
@@ -1,5 +1,9 @@
 const FORM_VALUE_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
 
+const ATTRIBUTE_ALIASES: Record<string, string> = {
+  htmlfor: "for",
+};
+
 const ENUMERATED_BOOLEAN_ATTRIBUTES: {
   [attributeName: string]: {
     trueValue: string;
@@ -36,6 +40,12 @@ function assignDomAttribute({
   previousValue?: any;
 }) {
   const normalizedAttributeName = attributeName.toLowerCase();
+  const domAttributeName = ATTRIBUTE_ALIASES[normalizedAttributeName] ?? attributeName;
+
+  if (normalizedAttributeName === "dangerouslysetinnerhtml") {
+    assignInnerHTML(htmlElement, value);
+    return;
+  }
 
   if (normalizedAttributeName === "value" && isFormValueElement(htmlElement)) {
     assignFormValueProperty(htmlElement, value);
@@ -52,8 +62,16 @@ function assignDomAttribute({
     return;
   }
 
-  if (attributeName === "style") {
+  if (normalizedAttributeName === "style") {
     assignStyle({ value, previousValue, htmlElement });
+    return;
+  }
+
+  if (
+    typeof value === "boolean" &&
+    (normalizedAttributeName.startsWith("aria-") || normalizedAttributeName.startsWith("data-"))
+  ) {
+    htmlElement.setAttribute(domAttributeName, String(value));
     return;
   }
 
@@ -62,7 +80,7 @@ function assignDomAttribute({
 
     if (enumeratedConfig) {
       htmlElement.setAttribute(
-        attributeName,
+        domAttributeName,
         value ? enumeratedConfig.trueValue : enumeratedConfig.falseValue,
       );
       return;
@@ -72,9 +90,9 @@ function assignDomAttribute({
     // or duplicate the attribute name. A lack of the attribute means
     // the value is `false`.
     if (value) {
-      htmlElement.setAttribute(attributeName, "");
+      htmlElement.setAttribute(domAttributeName, "");
     } else {
-      htmlElement.removeAttribute(attributeName);
+      htmlElement.removeAttribute(domAttributeName);
     }
 
     return;
@@ -83,11 +101,22 @@ function assignDomAttribute({
   // setAttribute stringifies the value, and we don't want to assign null or undefined
   // as a string directly. Setting undefined/null means we don't need the attribute
   if (value == null) {
-    htmlElement.removeAttribute(attributeName);
+    htmlElement.removeAttribute(domAttributeName);
     return;
   }
 
-  htmlElement.setAttribute(attributeName, value);
+  htmlElement.setAttribute(domAttributeName, value);
+}
+
+function assignInnerHTML(htmlElement: HTMLElement, value: any) {
+  if (value == null) {
+    htmlElement.innerHTML = "";
+    return;
+  }
+
+  if (typeof value === "object" && "__html" in value) {
+    htmlElement.innerHTML = value.__html == null ? "" : String(value.__html);
+  }
 }
 
 function isFormValueElement(


### PR DESCRIPTION
## Description

Fix attributes normalization. There were several problems:

 - `dangerouslySetInnerHTML` becomes an attribute containing `"[object Object]"` and no HTML is inserted
 - `htmlFor` becomes `htmlfor`, not `for`
 - Boolean ARIA/data attributes use HTML boolean-attribute semantics. For example, `aria-hidden={false}` removes the attribute instead of producing `aria-hidden="false"`

This PR fixes these issues.